### PR TITLE
Update @orb.yml

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -60,7 +60,7 @@ commands:
           configuration. If omitted it's assumed the CLI has already been setup
           with a valid token.
         type: string
-        default: ""
+        default: $CIRCLE_TOKEN
     steps:
       - run:
           name: >
@@ -91,7 +91,7 @@ commands:
           configuration. If omitted it's assumed the CLI has already been setup
           with a valid token.
         type: string
-        default: ""
+        default: $CIRCLE_TOKEN
     steps:
       - run:
           name: >


### PR DESCRIPTION
default to `$CIRCLE_TOKEN` for token paramaters

this is already an established pattern, e.g., https://circleci.com/docs/2.0/env-vars/#injecting-environment-variables-with-the-api

makes things 1 step easier for folks