### PR TITLE
Ensure `tmp-config-src` directory exists

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -129,7 +129,6 @@ commands:
       - run:
           name: compile test config
           command: circleci config process uncompiled-config.yml > config.yml
-      - setup_remote_docker
       - run:
           name: run test job locally
           command: '<<# parameters.should-fail >>! <</ parameters.should-fail>>circleci local execute -c config.yml | tee local_build_output.txt /dev/stderr | tail -n 1 | grep "Success"'

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -119,6 +119,7 @@ commands:
         type: steps
         default: []
     steps:
+      - run: mkdir -p tmp-config-src
       - run: cp << parameters.test-config-location >> tmp-config-src/config.yml
       - pack:
           source: tmp-config-src

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -129,6 +129,7 @@ commands:
       - run:
           name: compile test config
           command: circleci config process uncompiled-config.yml > config.yml
+      - setup_remote_docker
       - run:
           name: run test job locally
           command: '<<# parameters.should-fail >>! <</ parameters.should-fail>>circleci local execute -c config.yml | tee local_build_output.txt /dev/stderr | tail -n 1 | grep "Success"'


### PR DESCRIPTION
It looks like this command will fail when the directory is missing.

Note: There might be a better temporary place for these files.