### PR TITLE
more strict gating on major releases

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 CircleCI Public
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -112,18 +112,22 @@ steps:
 
               echo "Commit range: $COMMIT_RANGE"
 
+              # only publish a major release if there are new jobs or commands
               if [[ $(git diff $COMMIT_RANGE --name-status | \
-                grep -e "src/commands" -e "src/jobs") ]]; then
+                grep -e "A      src/commands" -e "A      src/jobs") ]]; then
                 INTEGRATION_TAG=<<parameters.tag>>-major-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
 
+              # publish a minor release if there are other changes to jobs or commands
               elif [[ $(git diff $COMMIT_RANGE --name-status | \
-                grep -e "src/examples" -e "src/executors" -e "src/@orb.yml") ]]; then
+                grep -e "src/commands" -e "src/jobs") ]]; then
                 INTEGRATION_TAG=<<parameters.tag>>-minor-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
 
+              # patch release if any changers to examples, executors, @orb.yml
               elif [[ $(git diff $COMMIT_RANGE --name-status | \
-                grep -e "config.yml") ]]; then
+                grep -e "src/examples" -e "src/executors" -e "src/@orb.yml") ]]; then
                 INTEGRATION_TAG=<<parameters.tag>>-patch-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
 
+              # otherwise, don't publish a release
               else
                 INTEGRATION_TAG=<<parameters.tag>>-skip-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}
               fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

currently, the automated `git diff`-parsing logic in the `trigger-integration-workflow` job sets up the possibility of a major release anytime there are _any_ modifications whatsoever to `src/jobs` or `src/commands`. this is probably too low of a bar—major releases should represent some actual significant change to an orb.

### Description

expand our `git diff` logic just a bit. only set up a major release if there are _new_ jobs or commands. otherwise, modifications to existing jobs or commands trigger a  possible minor release. everything else that affects orb source code triggers a possible patch release. completely skip publishing if no actual orb source has been altered.

also, add MIT license, addressing https://github.com/CircleCI-Public/orb-tools-orb/issues/4