### PR TITLE
add cleanup-tags option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   circle-compare-url: iynere/compare-url@0.4.8
   cli: circleci/circleci-cli@0.1.2
-  orb-tools: circleci/orb-tools@5.0.3
+  orb-tools: circleci/orb-tools@8.0.0
   orb-tools-alpha: circleci/orb-tools@dev:alpha
 
 jobs:
@@ -71,7 +71,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          cleanup-tags: true
+          # cleanup-tags: true
           requires:
             - publish-dev
           filters:
@@ -81,7 +81,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-master
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          cleanup-tags: true
+          # cleanup-tags: true
           tag: master
           requires:
             - publish-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-dev
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
+          cleanup-tags: true
           requires:
             - publish-dev
           filters:
@@ -80,6 +81,7 @@ workflows:
       - orb-tools/trigger-integration-workflow:
           name: trigger-integration-master
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
+          cleanup-tags: true
           tag: master
           requires:
             - publish-dev

--- a/publish-alpha.sh
+++ b/publish-alpha.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+circleci config pack src > orb.yml
+circleci orb publish orb.yml circleci/orb-tools@dev:alpha
+rm -rf orb.yml

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -67,6 +67,13 @@ parameters:
       you will only be able to statically pick patch, minor, or major
       as a potential release type, by using the subsequent parameter.
 
+  cleanup-tags:
+    type: boolean
+    default: false
+    description: >
+      Before proceeding with pushing a tag to trigger an integration testing
+      workflow, optionally cleanup all previous remote tags.
+
   static-release-type:
     type: enum
     default: patch
@@ -96,6 +103,21 @@ steps:
       command: |
         git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
         git config --global user.name "$CIRCLE_USERNAME"
+
+  - when:
+      condition: <<parameters.cleanup-tags>>
+      steps:
+        - run:
+            name: cleanup old remote tags
+            command: |
+              # delete local tags
+              git tag -d $(git tag -l)
+
+              # fetch remote tags
+              git fetch
+
+              # delete remote tags
+              git push origin --delete $(git tag -l) # pushing once should be faster than multiple times
 
   - when:
       condition: <<parameters.use-git-diff>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

the tag-triggered integration testing workflow results in creation of lots of tags, which by default are orphaned unless someone specifically adds logic to clean them up

### Description

add param to the `trigger-integration-workflow` job to clean up old tags before pushing a new one
