### PR TITLE
Fix status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Orb Tools Orb ![CircleCI status](https://circleci.com/gh/CircleCI-Public/orb-tools-orb.svg "CircleCI status")
+# Orb Tools Orb [![CircleCI status](https://circleci.com/gh/CircleCI-Public/orb-tools-orb.svg "CircleCI status")](https://circleci.com/gh/CircleCI-Public/orb-tools-orb)
 An orb for orb authors.
 
 


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The status badge currently doesn't link to CircleCI builds of the project.

### Description

Make the status badge link to the CircleCI builds of the project
