### PR TITLE
jobs/trigger-integration-workflow: Make ssh-fingerprints optional

### DIFF
--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -36,6 +36,7 @@ parameters:
 
   ssh-fingerprints:
     type: string
+    default: ""
     description: >
       Fingerprints for SSH deploy key (add the public key as a read/write
       key on GitHub; add the private key in CircleCI via SSH Permissions,
@@ -94,9 +95,12 @@ steps:
         - attach_workspace:
             at: <<parameters.workspace-root>>
 
-  - add_ssh_keys:
-      fingerprints:
-        - <<parameters.ssh-fingerprints>>
+  - when:
+      condition: <<parameters.ssh-fingerprints>>
+      steps:
+        - add_ssh_keys:
+            fingerprints:
+              - <<parameters.ssh-fingerprints>>
 
   - run:
       name: git config


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

In specific cases, it is not necessary to use the `add_ssh_keys`
command prior to pushing the tag.

### Description

Make the specification of the `ssh-fingerprints` parameter optional
and only execute the `add_ssh_keys` step if fingerprints are provided.

Addresses: #23