### PR TITLE
Add common testing executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  circle-compare-url: iynere/compare-url@0.4.9
+  circle-compare-url: iynere/compare-url@1.0.0
   cli: circleci/circleci-cli@0.1.2
-  orb-tools: circleci/orb-tools@8.5.0
+  orb-tools: circleci/orb-tools@8.9.2
   orb-tools-alpha: circleci/orb-tools@dev:alpha
 
 jobs:
@@ -13,7 +13,13 @@ jobs:
   # trigger-integration goes here: see workflow
 
   test-commands:
-    executor: cli/default
+    parameters:
+      executor:
+        type: executor
+        default: cli/default
+
+    executor: <<parameters.executor>>
+
     steps:
       - checkout
 
@@ -46,7 +52,18 @@ integration-master_filters: &integration-master_filters
     only: /master-.*/
 
 prod-deploy_requires: &prod-deploy_requires
-  [test-commands-master, test-in-builds-job-master, test-publish-job-master, test-increment-job-master]
+  [
+    test-commands-master-cli,
+    test-commands-master-alpine,
+    test-commands-master-machine,
+    test-commands-master-macos,
+    test-commands-master-node-cci,
+    test-commands-master-node,
+    test-commands-master-ubuntu,
+    test-in-builds-job-master,
+    test-publish-job-master,
+    test-increment-job-master
+  ]
 
 workflows:
   lint_pack-validate_publish-dev:
@@ -95,11 +112,49 @@ workflows:
   integration_tests-prod_deploy:
     jobs:
       # triggered by non-master branch commits
+      # test commands with executors
       - test-commands:
-          name: test-commands-dev
+          name: test-commands-dev-cli
           context: orb-publishing
           filters: *integration-dev_filters
 
+      - test-commands:
+          name: test-commands-dev-alpine
+          executor: orb-tools-alpha/alpine
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      - test-commands:
+          name: test-commands-dev-machine
+          executor: orb-tools-alpha/machine
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      - test-commands:
+          name: test-commands-dev-macos
+          executor: orb-tools-alpha/macos
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      - test-commands:
+          name: test-commands-dev-node-cci
+          executor: orb-tools-alpha/node-cci
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      - test-commands:
+          name: test-commands-dev-node
+          executor: orb-tools-alpha/node
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      - test-commands:
+          name: test-commands-dev-ubuntu
+          executor: orb-tools-alpha/ubuntu
+          context: orb-publishing
+          filters: *integration-dev_filters
+
+      # test jobs
       - orb-tools-alpha/pack:
           name: test-pack-job-dev
           workspace-path: orb.yml
@@ -146,11 +201,49 @@ workflows:
             - test-publish-job-dev
 
       # triggered by master branch commits
+      # test commands with executors
       - test-commands:
-          name: test-commands-master
+          name: test-commands-master-cli
           context: orb-publishing
           filters: *integration-master_filters
 
+      - test-commands:
+          name: test-commands-master-alpine
+          executor: orb-tools-alpha/alpine
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - test-commands:
+          name: test-commands-master-machine
+          executor: orb-tools-alpha/machine
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - test-commands:
+          name: test-commands-master-macos
+          executor: orb-tools-alpha/macos
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - test-commands:
+          name: test-commands-master-node-cci
+          executor: orb-tools-alpha/node-cci
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - test-commands:
+          name: test-commands-master-node
+          executor: orb-tools-alpha/node
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      - test-commands:
+          name: test-commands-master-ubuntu
+          executor: orb-tools-alpha/ubuntu
+          context: orb-publishing
+          filters: *integration-master_filters
+
+      # test jobs
       - orb-tools-alpha/pack:
           name: test-pack-job-master
           workspace-path: orb.yml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,30 +136,35 @@ workflows:
           executor: orb-tools-alpha/machine
           context: orb-publishing
           filters: *integration-dev_filters
+          pre-steps: [run: sleep 1]
 
       - test-commands:
           name: test-commands-dev-macos
           executor: orb-tools-alpha/macos
           context: orb-publishing
           filters: *integration-dev_filters
+          pre-steps: [run: sleep 2]
 
       - test-commands:
           name: test-commands-dev-node-cci
           executor: orb-tools-alpha/node-cci
           context: orb-publishing
           filters: *integration-dev_filters
+          pre-steps: [run: sleep 3]
 
       - test-commands:
           name: test-commands-dev-node
           executor: orb-tools-alpha/node
           context: orb-publishing
           filters: *integration-dev_filters
+          pre-steps: [run: sleep 4]
 
       - test-commands:
           name: test-commands-dev-ubuntu
           executor: orb-tools-alpha/ubuntu
           context: orb-publishing
           filters: *integration-dev_filters
+          pre-steps: [run: sleep 5]
 
       # test jobs
       - orb-tools-alpha/pack:
@@ -220,30 +225,35 @@ workflows:
           executor: orb-tools-alpha/machine
           context: orb-publishing
           filters: *integration-master_filters
+          pre-steps: [run: sleep 1]
 
       - test-commands:
           name: test-commands-master-macos
           executor: orb-tools-alpha/macos
           context: orb-publishing
           filters: *integration-master_filters
+          pre-steps: [run: sleep 2]
 
       - test-commands:
           name: test-commands-master-node-cci
           executor: orb-tools-alpha/node-cci
           context: orb-publishing
           filters: *integration-master_filters
+          pre-steps: [run: sleep 3]
 
       - test-commands:
           name: test-commands-master-node
           executor: orb-tools-alpha/node
           context: orb-publishing
           filters: *integration-master_filters
+          pre-steps: [run: sleep 4]
 
       - test-commands:
           name: test-commands-master-ubuntu
           executor: orb-tools-alpha/ubuntu
           context: orb-publishing
           filters: *integration-master_filters
+          pre-steps: [run: sleep 5]
 
       # test jobs
       - orb-tools-alpha/pack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,35 +136,35 @@ workflows:
           executor: orb-tools-alpha/machine
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 1]
+          pre-steps: [run: sleep 2]
 
       - test-commands:
           name: test-commands-dev-macos
           executor: orb-tools-alpha/macos
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 2]
+          pre-steps: [run: sleep 4]
 
       - test-commands:
           name: test-commands-dev-node-cci
           executor: orb-tools-alpha/node-cci
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 3]
+          pre-steps: [run: sleep 6]
 
       - test-commands:
           name: test-commands-dev-node
           executor: orb-tools-alpha/node
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 4]
+          pre-steps: [run: sleep 8]
 
       - test-commands:
           name: test-commands-dev-ubuntu
           executor: orb-tools-alpha/ubuntu
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 5]
+          pre-steps: [run: sleep 10]
 
       # test jobs
       - orb-tools-alpha/pack:
@@ -225,35 +225,35 @@ workflows:
           executor: orb-tools-alpha/machine
           context: orb-publishing
           filters: *integration-master_filters
-          pre-steps: [run: sleep 1]
+          pre-steps: [run: sleep 2]
 
       - test-commands:
           name: test-commands-master-macos
           executor: orb-tools-alpha/macos
           context: orb-publishing
           filters: *integration-master_filters
-          pre-steps: [run: sleep 2]
+          pre-steps: [run: sleep 4]
 
       - test-commands:
           name: test-commands-master-node-cci
           executor: orb-tools-alpha/node-cci
           context: orb-publishing
           filters: *integration-master_filters
-          pre-steps: [run: sleep 3]
+          pre-steps: [run: sleep 6]
 
       - test-commands:
           name: test-commands-master-node
           executor: orb-tools-alpha/node
           context: orb-publishing
           filters: *integration-master_filters
-          pre-steps: [run: sleep 4]
+          pre-steps: [run: sleep 8]
 
       - test-commands:
           name: test-commands-master-ubuntu
           executor: orb-tools-alpha/ubuntu
           context: orb-publishing
           filters: *integration-master_filters
-          pre-steps: [run: sleep 5]
+          pre-steps: [run: sleep 10]
 
       # test jobs
       - orb-tools-alpha/pack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   circle-compare-url: iynere/compare-url@1.0.0
-  cli: circleci/circleci-cli@0.1.2
+  cli: circleci/circleci-cli@0.1.4
   orb-tools: circleci/orb-tools@8.9.2
   orb-tools-alpha: circleci/orb-tools@dev:alpha
 
@@ -16,12 +16,13 @@ jobs:
     parameters:
       executor:
         type: executor
-        default: cli/default
 
     executor: <<parameters.executor>>
 
     steps:
       - checkout
+
+      - cli/install
 
       - orb-tools-alpha/install-bats
       - orb-tools-alpha/pack
@@ -53,16 +54,27 @@ integration-master_filters: &integration-master_filters
 
 prod-deploy_requires: &prod-deploy_requires
   [
-    test-commands-master-cli,
+    test-increment-job-master
+  ]
+
+requires_commands_dev: &requires_commands_dev
+  [
+    test-commands-dev-alpine,
+    test-commands-dev-machine,
+    test-commands-dev-macos,
+    test-commands-dev-node-cci,
+    test-commands-dev-node,
+    test-commands-dev-ubuntu
+  ]
+
+requires_commands_master: &requires_commands_master
+  [
     test-commands-master-alpine,
     test-commands-master-machine,
     test-commands-master-macos,
     test-commands-master-node-cci,
     test-commands-master-node,
-    test-commands-master-ubuntu,
-    test-in-builds-job-master,
-    test-publish-job-master,
-    test-increment-job-master
+    test-commands-master-ubuntu
   ]
 
 workflows:
@@ -114,11 +126,6 @@ workflows:
       # triggered by non-master branch commits
       # test commands with executors
       - test-commands:
-          name: test-commands-dev-cli
-          context: orb-publishing
-          filters: *integration-dev_filters
-
-      - test-commands:
           name: test-commands-dev-alpine
           executor: orb-tools-alpha/alpine
           context: orb-publishing
@@ -167,7 +174,7 @@ workflows:
           attach-workspace: true
           orb-name: orb-tools-alpha
           filters: *integration-dev_filters
-          requires: [test-pack-job-dev]
+          requires: *requires_commands_dev
           test-steps:
             - checkout
 
@@ -187,8 +194,7 @@ workflows:
           context: orb-publishing
           orb-ref: sandbox/orb-tools@dev:$CIRCLE_TAG
           filters: *integration-dev_filters
-          requires:
-            - test-pack-job-dev
+          requires: *requires_commands_dev
 
       - orb-tools-alpha/increment:
           name: test-increment-job-dev
@@ -202,11 +208,6 @@ workflows:
 
       # triggered by master branch commits
       # test commands with executors
-      - test-commands:
-          name: test-commands-master-cli
-          context: orb-publishing
-          filters: *integration-master_filters
-
       - test-commands:
           name: test-commands-master-alpine
           executor: orb-tools-alpha/alpine
@@ -256,7 +257,7 @@ workflows:
           attach-workspace: true
           orb-name: orb-tools-alpha
           filters: *integration-master_filters
-          requires: [test-pack-job-master]
+          requires: *requires_commands_master
           test-steps:
             - checkout
 
@@ -276,8 +277,7 @@ workflows:
           context: orb-publishing
           orb-ref: sandbox/orb-tools@dev:$CIRCLE_TAG
           filters: *integration-master_filters
-          requires:
-            - test-pack-job-master
+          requires: *requires_commands_master
 
       - orb-tools-alpha/increment:
           name: test-increment-job-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ workflows:
           workspace-path: orb.yml
           artifact-path: orb.yml
           filters: *integration-dev_filters
+          requires: *requires_commands_dev
 
       - orb-tools-alpha/test-in-builds:
           name: test-in-builds-job-dev
@@ -174,7 +175,7 @@ workflows:
           attach-workspace: true
           orb-name: orb-tools-alpha
           filters: *integration-dev_filters
-          requires: *requires_commands_dev
+          requires: [test-pack-job-dev]
           test-steps:
             - checkout
 
@@ -194,7 +195,7 @@ workflows:
           context: orb-publishing
           orb-ref: sandbox/orb-tools@dev:$CIRCLE_TAG
           filters: *integration-dev_filters
-          requires: *requires_commands_dev
+          requires: [test-pack-job-dev]
 
       - orb-tools-alpha/increment:
           name: test-increment-job-dev
@@ -250,6 +251,7 @@ workflows:
           workspace-path: orb.yml
           artifact-path: orb.yml
           filters: *integration-master_filters
+          requires: *requires_commands_master
 
       - orb-tools-alpha/test-in-builds:
           name: test-in-builds-job-master
@@ -257,7 +259,7 @@ workflows:
           attach-workspace: true
           orb-name: orb-tools-alpha
           filters: *integration-master_filters
-          requires: *requires_commands_master
+          requires: [test-pack-job-master]
           test-steps:
             - checkout
 
@@ -277,7 +279,7 @@ workflows:
           context: orb-publishing
           orb-ref: sandbox/orb-tools@dev:$CIRCLE_TAG
           filters: *integration-master_filters
-          requires: *requires_commands_master
+          requires: [test-pack-job-master]
 
       - orb-tools-alpha/increment:
           name: test-increment-job-master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ workflows:
           executor: orb-tools-alpha/machine
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 2]
+          # pre-steps: [run: sleep 2]
           segment: minor
 
       - test-commands:
@@ -152,7 +152,7 @@ workflows:
           executor: orb-tools-alpha/macos
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 4]
+          # pre-steps: [run: sleep 4]
           segment: major
 
       - test-commands:
@@ -160,14 +160,14 @@ workflows:
           executor: orb-tools-alpha/node-cci
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 6]
+          pre-steps: [run: sleep 2]
 
       - test-commands:
           name: test-commands-dev-node
           executor: orb-tools-alpha/node
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 8]
+          pre-steps: [run: sleep 2]
           segment: minor
 
       - test-commands:
@@ -175,7 +175,7 @@ workflows:
           executor: orb-tools-alpha/ubuntu
           context: orb-publishing
           filters: *integration-dev_filters
-          pre-steps: [run: sleep 10]
+          pre-steps: [run: sleep 2]
           segment: major
 
       # test jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,13 @@ jobs:
       executor:
         type: executor
 
+      segment:
+        description: >
+          The semver segment to increment 'major' or 'minor' or 'patch'
+        type: enum
+        enum: ["major", "minor", "patch"]
+        default: patch
+
     executor: <<parameters.executor>>
 
     steps:
@@ -36,6 +43,7 @@ jobs:
 
       - orb-tools-alpha/increment:
           orb-ref: sandbox/orb-tools
+          segment: <<parameters.segment>>
 
   # dev-promote-prod goes here: see workflow
 
@@ -137,6 +145,7 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
           pre-steps: [run: sleep 2]
+          segment: minor
 
       - test-commands:
           name: test-commands-dev-macos
@@ -144,6 +153,7 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
           pre-steps: [run: sleep 4]
+          segment: major
 
       - test-commands:
           name: test-commands-dev-node-cci
@@ -158,6 +168,7 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
           pre-steps: [run: sleep 8]
+          segment: minor
 
       - test-commands:
           name: test-commands-dev-ubuntu
@@ -165,6 +176,7 @@ workflows:
           context: orb-publishing
           filters: *integration-dev_filters
           pre-steps: [run: sleep 10]
+          segment: major
 
       # test jobs
       - orb-tools-alpha/pack:
@@ -226,6 +238,7 @@ workflows:
           context: orb-publishing
           filters: *integration-master_filters
           pre-steps: [run: sleep 2]
+          segment: minor
 
       - test-commands:
           name: test-commands-master-macos
@@ -233,6 +246,7 @@ workflows:
           context: orb-publishing
           filters: *integration-master_filters
           pre-steps: [run: sleep 4]
+          segment: major
 
       - test-commands:
           name: test-commands-master-node-cci
@@ -247,6 +261,7 @@ workflows:
           context: orb-publishing
           filters: *integration-master_filters
           pre-steps: [run: sleep 8]
+          segment: minor
 
       - test-commands:
           name: test-commands-master-ubuntu
@@ -254,6 +269,7 @@ workflows:
           context: orb-publishing
           filters: *integration-master_filters
           pre-steps: [run: sleep 10]
+          segment: major
 
       # test jobs
       - orb-tools-alpha/pack:

--- a/src/executors/alpine.yml
+++ b/src/executors/alpine.yml
@@ -1,3 +1,8 @@
+description: >
+  An Alpine Linux-based Docker image:
+  https://hub.docker.com/r/cibuilds/base
+  https://github.com/cibuilds/base
+
 parameters:
   resource-class:
     type: enum

--- a/src/executors/alpine.yml
+++ b/src/executors/alpine.yml
@@ -1,0 +1,10 @@
+parameters:
+  resource-class:
+    type: enum
+    default: small
+    enum: [small, medium, medium+, large, xlarge]
+
+resource_class: <<parameters.resource-class>>
+
+docker:
+  - image: cibuilds/base

--- a/src/executors/ci-base.yml
+++ b/src/executors/ci-base.yml
@@ -1,3 +1,0 @@
-resource_class: small
-docker:
-  - image: cibuilds/base

--- a/src/executors/lint.yml
+++ b/src/executors/lint.yml
@@ -1,3 +1,7 @@
+description: >
+  A Docker image with linting tools:
+  https://hub.docker.com/r/singapore/lint-condo
+
 resource_class: small
 
 docker:

--- a/src/executors/lint.yml
+++ b/src/executors/lint.yml
@@ -1,3 +1,4 @@
 resource_class: small
+
 docker:
   - image: singapore/lint-condo

--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -1,3 +1,7 @@
+description: >
+  CircleCI's Ubuntu-based machine executor VM:
+  https://circleci.com/docs/2.0/executor-types/#using-machine
+
 parameters:
   image:
     type: string

--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -1,0 +1,7 @@
+parameters:
+  image:
+    type: string
+    default: ubuntu-1604:201903-01
+
+machine:
+  image: <<parameters.image>>

--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -1,0 +1,7 @@
+parameters:
+  xcode-version:
+    type: string
+    default: "10.2.1"
+
+macos:
+  xcode: <<parameters.xcode-version>>

--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -1,3 +1,7 @@
+description: >
+  CircleCI's macOS executor VM:
+  https://circleci.com/docs/2.0/executor-types/#using-macos
+
 parameters:
   xcode-version:
     type: string

--- a/src/executors/node-cci.yml
+++ b/src/executors/node-cci.yml
@@ -1,3 +1,7 @@
+description: >
+  CircleCI's Node.js convenience Docker image:
+  https://hub.docker.com/r/circleci/node
+
 parameters:
   resource-class:
     type: enum

--- a/src/executors/node-cci.yml
+++ b/src/executors/node-cci.yml
@@ -1,0 +1,14 @@
+parameters:
+  resource-class:
+    type: enum
+    default: small
+    enum: [small, medium, medium+, large, xlarge]
+
+  tag:
+    type: string
+    default: boron
+
+resource_class: <<parameters.resource-class>>
+
+docker:
+  - image: circleci/node:<<parameters.tag>>

--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -1,3 +1,7 @@
+description: >
+  Docker's official Node image:
+  http://hub.docker.com/_/node
+
 parameters:
   resource-class:
     type: enum

--- a/src/executors/node.yml
+++ b/src/executors/node.yml
@@ -1,0 +1,14 @@
+parameters:
+  resource-class:
+    type: enum
+    default: small
+    enum: [small, medium, medium+, large, xlarge]
+
+  tag:
+    type: string
+    default: latest
+
+resource_class: <<parameters.resource-class>>
+
+docker:
+  - image: node:<<parameters.tag>>

--- a/src/executors/ubuntu.yml
+++ b/src/executors/ubuntu.yml
@@ -1,0 +1,14 @@
+parameters:
+  resource-class:
+    type: enum
+    default: small
+    enum: [small, medium, medium+, large, xlarge]
+
+  tag:
+    type: string
+    default: latest
+
+resource_class: <<parameters.resource-class>>
+
+docker:
+  - image: circleciimages/base:<<parameters.tag>>

--- a/src/executors/ubuntu.yml
+++ b/src/executors/ubuntu.yml
@@ -1,3 +1,9 @@
+description: >
+  The Ubuntu Linux base image for CircleCI's revamped convenience
+  images pilot project:
+  http://github.com/circleci-public/cimg-base
+  https://github.com/circleci-public/cimg-overview
+
 parameters:
   resource-class:
     type: enum

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -4,7 +4,7 @@ description: >
   corresponding GitHub repo for the project. See examples for further
   usage details.
 
-executor: ci-base
+executor: alpine
 
 parameters:
   checkout:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

a lot of orbs end up using the same executors to test orb functionality across various execution environments. by hardcoding them into orb-tools, we can save a lot of boilerplate in orb repos' config.yml files

### Description

add executors commonly used in orb-testing