### PR TITLE
fix: Allows to use any string as tag for trigger-integration-workflow

### DIFF
--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -44,13 +44,10 @@ parameters:
       project's repository.
 
   tag:
-    type: enum
+    type: string
     default: integration
-    enum: [integration, master]
     description: >
-      Will this integration trigger integration (integration tests
-      only) or master (integration tests, plus potential deployment of
-      production/semantic orb release) workflow jobs?
+      Prefix used for the tag created on GitHub, default is "integration"
 
   use-git-diff:
     type: boolean


### PR DESCRIPTION
### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

In my use case I have a mono-repository for all my orbs. I need to be able to specify the tag used during the job `trigger-integration-workflow` to be able to trigger different deployment according to which orbs have been changed.

### Description

- modify `tag` parameter to job `trigger-integration-workflow` from `enum` to `string`

