### PR TITLE
[WIP] populate git tag message

### DIFF
--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -62,10 +62,7 @@ steps:
           <<parameters.release>> --token \
           $<<parameters.publish-token-variable>>
 
-  - run:
-      name: success! your new orb release was published to the orb registry
-      command: |
-        echo "visit your orb in the orb registry:"
+        echo "View this orb release in the orb registry:"
         echo "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>"
 
   - when:
@@ -94,5 +91,5 @@ steps:
               NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')
 
               TAG="v$NEW_VERSION-<<parameters.release>>"
-              git tag "$TAG"
+              git tag -a "$TAG" -m "### View this orb release in the orb registry" -m "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>?$NEW_VERSION=8.18.0"
               git push origin "$TAG"

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -91,5 +91,11 @@ steps:
               NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')
 
               TAG="v$NEW_VERSION-<<parameters.release>>"
-              git tag -a "$TAG" -m "### View this orb release in the orb registry" -m "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>?$NEW_VERSION=8.18.0"
+
+              git tag -a "$TAG" \
+                -m "### View this orb release in the [orb registry](https://circleci.com/orbs/registry)" \
+                -m "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>?version=$NEW_VERSION" \
+                -m "### View this orb release using the [CircleCI CLI](https://circleci-public.github.io/circleci-cli)" \
+                -m "`circleci orb source <<parameters.orb-name>>@$NEW_VERSION`"
+
               git push origin "$TAG"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

`dev-promote-prod` can now publish SemVer tag releases, which is awesome, but they're fairly minimal

### Description

flesh out the version tag that gets created, by adding a tag message body including a link to the registry URL for that specific release (don't merge this until AFTER that registry functionality is in production) & the circleci CLI command to view that SemVer in your terminal
