### PR TITLE
`check-env-var-param` can check multiple env var params

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - orb-tools-alpha/validate
 
       - orb-tools-alpha/check-env-var-param:
-          param: CIRCLE_BUILD_NUM
+          param: CIRCLE_BUILD_NUM,CIRCLE_BRANCH,CIRCLE_BUILD_URL,CIRCLE_JOB
 
       - orb-tools-alpha/publish:
           orb-ref: sandbox/orb-tools@dev:$CIRCLE_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - orb-tools-alpha/validate
 
       - orb-tools-alpha/check-env-var-param:
+          command-name: Test `check-env-var-param` command with built-in env vars
           param: CIRCLE_BUILD_NUM,CIRCLE_BRANCH,CIRCLE_BUILD_URL,CIRCLE_JOB
 
       - orb-tools-alpha/publish:

--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -2,6 +2,11 @@ description: >
   Check that env-var parameters are defined, produce an error otherwise
 
 parameters:
+  command-name:
+    type: string
+    default: Checking if parameters are defined...
+    description: Name for CircleCI step output
+
   param:
     type: string
     description: >

--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -33,14 +33,14 @@ steps:
 
         for i in "${PARAMS[@]}"; do
           if [[ -z "${i}" ]]; then
-          echo "ERROR: Missing environment variable {i}" >&2
+            echo "ERROR: Missing environment variable {i}" >&2
 
-          if [[ -n "<<parameters.error-message>>" ]]; then
-            echo "<<parameters.error-message>>" >&2
+            if [[ -n "<<parameters.error-message>>" ]]; then
+              echo "<<parameters.error-message>>" >&2
+            fi
+
+            <<#parameters.exit-if-undefined>>exit 1<</parameters.exit-if-undefined>>
+          else
+            echo "Yes, ${i} is defined!"
           fi
-
-          <<#parameters.exit-if-undefined>>exit 1<</parameters.exit-if-undefined>>
-        else
-          echo "Yes, all parameters are defined!"
-        fi
         done

--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -1,10 +1,14 @@
 description: >
-  Check that an env-var parameter is defined, produce an error otherwise
+  Check that env-var parameters are defined, produce an error otherwise
 
 parameters:
   param:
-    type: env_var_name
-    description: Name of the environment variable to check
+    type: string
+    description: >
+      Comma-separated list of `env_var_name` type values, all will be
+      checked to ensure they are defined. Designed to be called at the
+      beginning of an orb job or command, with a value like the following:
+      `<<parameters.foo>>,<<parameters.bar>>,<<parameters.baz>`, etc.
 
   error-message:
     type: string
@@ -23,14 +27,20 @@ parameters:
 
 steps:
   - run:
-      name: Checking if $<<parameters.param>> is defined...
+      name: Checking if parameters are defined...
       command: |
-        if [[ -z "${<<parameters.param>>}" ]]; then
-          echo "ERROR: Missing environment variable <<parameters.param>>" >&2
+        IFS="," read -ra PARAMS \<<< "<<parameters.param>>"
+
+        for i in "${PARAMS[@]}"; do
+          if [[ -z "${i}" ]]; then
+          echo "ERROR: Missing environment variable {i}" >&2
+
           if [[ -n "<<parameters.error-message>>" ]]; then
             echo "<<parameters.error-message>>" >&2
           fi
+
           <<#parameters.exit-if-undefined>>exit 1<</parameters.exit-if-undefined>>
         else
-          echo "Yes, <<parameters.param>> is defined!"
+          echo "Yes, all parameters are defined!"
         fi
+        done

--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -5,7 +5,7 @@ parameters:
   param:
     type: string
     description: >
-      Comma-separated list of `env_var_name` type values, all will be
+      Comma-separated list of `env_var_name`-type value; all will be
       checked to ensure they are defined. Designed to be called at the
       beginning of an orb job or command, with a value like the following:
       `<<parameters.foo>>,<<parameters.bar>>,<<parameters.baz>`, etc.

--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -32,7 +32,7 @@ parameters:
 
 steps:
   - run:
-      name: Checking if parameters are defined...
+      name: <<parameters.command-name>>
       command: |
         IFS="," read -ra PARAMS \<<< "<<parameters.param>>"
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

- `check-env-var-param` currently can only check 1 parameter, which is a slightly blocking limitation to widespread usage

### Description

- make it take a comma-separated list of strings, check each
