### PR TITLE
trigger-integration-workflow: make cleanup-tags use tag parameter

### DIFF
--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -129,14 +129,14 @@ steps:
             name: cleanup old remote tags
             command: |
               # delete local tags
-              git tag -d $(git tag -l "integration-*")
+              git tag -d $(git tag -l "<<parameters.tag>>-*")
               git tag -d $(git tag -l "master-skip-master-*")
 
               # fetch remote tags
               git fetch
 
               # delete remote tags
-              git push origin --delete $(git tag -l "integration-*") || true
+              git push origin --delete $(git tag -l "<<parameters.tag>>-*") || true
               git push origin --delete $(git tag -l "master-skip-master-*") || true # pushing once should be faster than multiple times
 
   - when:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
resolves #41 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Change `trigger-integration-workflow` to make its `cleanup-tags` option delete previous tags matching the `tag` parameter.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
