### PR TITLE
Revise tag cleanup

### DIFF
--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -35,9 +35,22 @@ parameters:
     type: boolean
     default: true
     description: >
-      Delete the tag used to trigger this workflow and replace it with
-      a tag describing the release that was just published. If `true`,
-      make sure to pass SSH fingerprints, as well.
+      Push a git tag describing the release that was just published? If `true`,
+      make sure to pass SSH fingerprints, as well
+
+  cleanup-tags:
+    type: boolean
+    default: false
+    description: >
+      After publishing a version tag for a successful orb deployment, clean
+      up older tags? Use the `cleanup-tags-pattern` parameter to specify
+      which tags should be removed
+
+  cleanup-tags-pattern:
+    type: string
+    default: "master*"
+    description: >
+      After publishing a version tag for a successful orb deployment, optionally clean up all older tags that meet a given `git tag -l` wildcard pattern. Defaults to a wildcard pattern including any tags starting with the string `master`.
 
   ssh-fingerprints:
     type: string
@@ -78,15 +91,6 @@ steps:
               git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
               git config --global user.name "$CIRCLE_USERNAME"
 
-              # delete local tag
-              git tag -d $(git tag -l "$CIRCLE_TAG")
-
-              # fetch remote tags
-              git fetch
-
-              # delete remote tag
-              git push origin --delete $(git tag -l "$CIRCLE_TAG")
-
               # construct/push new tag
               NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')
 
@@ -100,3 +104,12 @@ steps:
                 -m "\`circleci orb source <<parameters.orb-name>>@$NEW_VERSION\`"
 
               git push origin "$TAG"
+
+              # delete local tags
+              git tag -d $(git tag -l "<<parameters.cleanup-tags-pattern>>")
+
+              # fetch remote tags
+              git fetch
+
+              # delete remote tag
+              git push origin --delete $(git tag -l git tag -l "<<parameters.cleanup-tags-pattern>>") || true

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -135,21 +135,6 @@ steps:
         git config --global user.name "$CIRCLE_USERNAME"
 
   - when:
-      condition: <<parameters.cleanup-tags>>
-      steps:
-        - run:
-            name: cleanup old remote tags
-            command: |
-              # delete local tags
-              git tag -d $(git tag -l "<<parameters.cleanup-tags-pattern>>")
-
-              # fetch remote tags
-              git fetch
-
-              # delete remote tag
-              git push origin --delete $(git tag -l git tag -l "<<parameters.cleanup-tags-pattern>>") || true
-
-  - when:
       condition: <<parameters.use-git-diff>>
       steps:
         - circle-compare-url/reconstruct:
@@ -190,3 +175,18 @@ steps:
 
               git tag $INTEGRATION_TAG
               git push origin $INTEGRATION_TAG
+
+  - when:
+      condition: <<parameters.cleanup-tags>>
+      steps:
+        - run:
+            name: cleanup old remote tags
+            command: |
+              # delete local tags
+              git tag -d $(git tag -l "<<parameters.cleanup-tags-pattern>>")
+
+              # fetch remote tags
+              git fetch
+
+              # delete remote tag
+              git push origin --delete $(git tag -l git tag -l "<<parameters.cleanup-tags-pattern>>") || true

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -73,7 +73,19 @@ parameters:
     default: false
     description: >
       Before proceeding with pushing a tag to trigger an integration testing
-      workflow, optionally cleanup all previous remote tags
+      workflow, optionally cleanup some previous remote tags? Use the
+      `cleanup-tags-pattern` parameter to specify which tags should be
+      removed
+
+  cleanup-tags-pattern:
+    type: string
+    default: "integration*"
+    description: >
+      Before proceeding with pushing a tag to trigger an integration testing
+      workflow, optionally clean up all older tags that meet a given
+      `git tag -l` wildcard pattern. Defaults to a wildcard pattern
+      including any tags starting with the string `integration`.
+      (Default is intended for use when `tag` parameter is set to `master`.)
 
   static-release-type:
     type: enum
@@ -129,15 +141,13 @@ steps:
             name: cleanup old remote tags
             command: |
               # delete local tags
-              git tag -d $(git tag -l "<<parameters.tag>>-*")
-              git tag -d $(git tag -l "master-skip-master-*")
+              git tag -d $(git tag -l "<<parameters.cleanup-tags-pattern>>")
 
               # fetch remote tags
               git fetch
 
-              # delete remote tags
-              git push origin --delete $(git tag -l "<<parameters.tag>>-*") || true
-              git push origin --delete $(git tag -l "master-skip-master-*") || true # pushing once should be faster than multiple times
+              # delete remote tag
+              git push origin --delete $(git tag -l git tag -l "<<parameters.cleanup-tags-pattern>>") || true
 
   - when:
       condition: <<parameters.use-git-diff>>


### PR DESCRIPTION
### Revise tag cleanup schemes for better automated pipelines

We've made some changes to the tag deletion recently, and I wanted to make things a bit better, if possible.

Rather than hardcoding certain tagging patterns for optional deletion, just fully parameterize the `git tag -l` pattern that will be cleaned up.

Also, add the same functionality to the `dev-promote-prod` job, since it was already doing some (previously hardcoded) optional tag cleanup.

The goal here is to have orb repos where the only tags that remain, are those following a `vX.Y.Z` SemVer pattern, which is the default published when using `dev-promote-prod` with `publish-version-tag` set to `true`.

The way to achieve this is specified in the default values for `cleanup-tags-pattern` in both jobs in which it now appears:

- In `trigger-integration-workflow`, the default will cleanup all tags starting with the string `integration`, intended to be used only when `trigger-integration-workflow` is run on a commit to master, e.g., when its `tag` parameter is set to `master`.
- In `dev-promote-prod`, the default will cleanup all tags starting with the string `master`, and will only run _after_ a successful orb deployment.

And, as a reminder, these cleanup schemes will _only_ get used when `cleanup-tags` is set to `true` (its default value is `false`).