### PR TITLE
Installing git and openssh when checkout is specified

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -55,6 +55,10 @@ steps:
   - when:
       condition: <<parameters.checkout>>
       steps:
+        - run:
+            name: "Install Git and Openssh"
+            command: |
+              apk --update add git openssh
         - checkout
 
   - when:


### PR DESCRIPTION
Signed-off-by: Andrew Suderman <andrew@sudermanjr.com>

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes #45 

When building an annotated tag, git and openssh are required to checkout.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Add a run block before code checkout that runs `apk --update add git openssh`
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
