### PR TITLE
Adds opinionated semver promote command and use in promote job [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
   cli: circleci/circleci-cli@0.1.4
   # Use temporary dev version in order to make use of
   # the new dev-promote-semver command
-  #  Published in https://circleci.com/gh/CircleCI-Public/orb-tools-orb/2260
-  orb-tools: circleci/orb-tools@dev:cf9f554
+  # Published in https://circleci.com/gh/CircleCI-Public/orb-tools-orb/2368
+  orb-tools: circleci/orb-tools@dev:688c761
   orb-tools-alpha: circleci/orb-tools@dev:alpha
   queue: eddiewebb/queue@1.1.2
 
@@ -318,7 +318,6 @@ workflows:
           context: orb-publishing
           orb-name: circleci/orb-tools
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          cleanup-tags: true
           requires: *prod-deploy_requires
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,9 +308,9 @@ workflows:
             - test-in-builds-job-master
             - test-publish-job-master
 
-      # patch, minor, or major publishing
+      # semver publishing
       - orb-tools/dev-promote-prod:
-          name: dev-promote-patch
+          name: dev-promote-semver
           add-pr-comment: true
           bot-user: cpe-bot
           bot-token-variable: GHI_TOKEN
@@ -323,36 +323,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /master-patch.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-minor
-          add-pr-comment: true
-          bot-user: cpe-bot
-          bot-token-variable: GHI_TOKEN
-          context: orb-publishing
-          orb-name: circleci/orb-tools
-          ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          cleanup-tags: true
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-major
-          add-pr-comment: true
-          bot-user: cpe-bot
-          bot-token-variable: GHI_TOKEN
-          context: orb-publishing
-          orb-name: circleci/orb-tools
-          ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          cleanup-tags: true
-          requires: *prod-deploy_requires
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/
+              only: /master-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ orbs:
   cli: circleci/circleci-cli@0.1.4
   # Use temporary dev version in order to make use of
   # the new dev-promote-semver command
-  orb-tools: circleci/orb-tools@dev:promote-semver
+  # Published in https://circleci.com/gh/CircleCI-Public/orb-tools-orb/2165
+  orb-tools: circleci/orb-tools@dev:0dad3e4
   orb-tools-alpha: circleci/orb-tools@dev:alpha
   queue: eddiewebb/queue@1.1.2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@ version: 2.1
 
 orbs:
   cli: circleci/circleci-cli@0.1.4
-  orb-tools: circleci/orb-tools@8.27.3
+  # Use temporary dev version in order to make use of
+  # the new dev-promote-semver command
+  orb-tools: circleci/orb-tools@dev:promote-semver
   orb-tools-alpha: circleci/orb-tools@dev:alpha
   queue: eddiewebb/queue@1.1.2
 
@@ -309,6 +311,9 @@ workflows:
       # patch, minor, or major publishing
       - orb-tools/dev-promote-prod:
           name: dev-promote-patch
+          add-pr-comment: true
+          bot-user: cpe-bot
+          bot-token-variable: GHI_TOKEN
           context: orb-publishing
           orb-name: circleci/orb-tools
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
@@ -322,7 +327,9 @@ workflows:
 
       - orb-tools/dev-promote-prod:
           name: dev-promote-minor
-          release: minor
+          add-pr-comment: true
+          bot-user: cpe-bot
+          bot-token-variable: GHI_TOKEN
           context: orb-publishing
           orb-name: circleci/orb-tools
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
@@ -336,7 +343,9 @@ workflows:
 
       - orb-tools/dev-promote-prod:
           name: dev-promote-major
-          release: major
+          add-pr-comment: true
+          bot-user: cpe-bot
+          bot-token-variable: GHI_TOKEN
           context: orb-publishing
           orb-name: circleci/orb-tools
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
   cli: circleci/circleci-cli@0.1.4
   # Use temporary dev version in order to make use of
   # the new dev-promote-semver command
-  # Published in https://circleci.com/gh/CircleCI-Public/orb-tools-orb/2165
-  orb-tools: circleci/orb-tools@dev:0dad3e4
+  #  Published in https://circleci.com/gh/CircleCI-Public/orb-tools-orb/2260
+  orb-tools: circleci/orb-tools@dev:cf9f554
   orb-tools-alpha: circleci/orb-tools@dev:alpha
   queue: eddiewebb/queue@1.1.2
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ workflows:
               only: /master-.*/
 
       # publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major]"
+      # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major
-      # version will be published.
+      # version will be published or if publishing should
+      # be skipped.
       # e.g. [semver:patch] will cause a patch version to be published.
       - orb-tools/dev-promote-prod:
           orb-name: your-namespace/your-orb

--- a/README.md
+++ b/README.md
@@ -94,43 +94,21 @@ workflows:
             tags:
               only: /master-.*/
 
-      # patch, minor, or major publishing, depending on which orb source
-      # files have been modified (that logic lives in the
-      # trigger-integration-workflow job's source)
+      # publish a semver version of the orb. relies on
+      # the commit subject containing the text "[semver:patch|minor|major]"
+      # as that will determine whether a patch, minor or major
+      # version will be published.
+      # e.g. [semver:patch] will cause a patch version to be published.
       - orb-tools/dev-promote-prod:
-          name: dev-promote-patch
           orb-name: your-namespace/your-orb
+          add-pr-comment: false
           requires:
             - integration-tests-master
           filters:
             branches:
               ignore: /.*/
             tags:
-              only: /master-patch.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-minor
-          release: minor
-          orb-name: your-namespace/your-orb
-          requires:
-            - integration-tests-master
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-minor.*/
-
-      - orb-tools/dev-promote-prod:
-          name: dev-promote-major
-          release: major
-          orb-name: your-namespace/your-orb
-          requires:
-            - integration-tests-master
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /master-major.*/
+              only: /master-.*/
 ```
 
 ## Contributing

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -1,8 +1,8 @@
 description: >
-  Uses the CLI to promote a dev version of an orb to the registry. 
+  Uses the CLI to promote a dev version of an orb to the registry.
   This command supports Semantic Versioning support. In order to promote
   the commit subject must include the `[semver:FOO]` pattern.
-  i.e. 'Merge pull request #XX from some-branch [semver:minor]' 
+  i.e. 'Merge pull request #XX from some-branch [semver:minor]'
 
 parameters:
   dev-version:
@@ -48,7 +48,7 @@ steps:
       - run:
           name: Promote to prod
           command: |
-            SEMVER_INCREMENT=`jq -r '.subject' /tmp/build_info.txt | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
+            SEMVER_INCREMENT=`git log -1 --pretty=%s. | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
             if [ -z ${SEMVER_INCREMENT} ];then
               echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
               exit 1
@@ -58,15 +58,16 @@ steps:
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
       - when:
-          conditions: <<parameters.add-pr-comment>>
-            run:
-          name: Publish Prod version to PR
-          command: |
-            PR_NUMBER=`jq -r '.subject' /tmp/build_info.txt | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
-            echo "PR_NUMBER is ${PR_NUMBER}"
-            if [ "$PR_NUMBER" == "" ];then
-              echo "No pr found, do nothing. If this is a mistake, be sure your commit subject includes the pattern:"
-              echo "\tMerge pull request #XX from some-branch [semver:patch]"
-              exit 0
-            fi
-            curl -X POST -u "<<parameters.bot-user>>:<<parameters.bot-token>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"
+          condition: <<parameters.add-pr-comment>>
+          steps:
+            - run:
+                name: Publish Prod version to PR
+                command: |
+                  PR_NUMBER=`jq -r '.subject' /tmp/build_info.txt | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
+                  echo "PR_NUMBER is ${PR_NUMBER}"
+                  if [ "$PR_NUMBER" == "" ];then
+                    echo "No pr found, do nothing. If this is a mistake, be sure your commit subject includes the pattern:"
+                    echo "\tMerge pull request #XX from some-branch [semver:patch]"
+                    exit 0
+                  fi
+                  curl -X POST -u "<<parameters.bot-user>>:<<parameters.bot-token>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -21,11 +21,11 @@ parameters:
 
   add-pr-comment:
     description: >
-      CircleCI can comment on the merged PR with the final production version. 
-      If you want contributors to see a message with the production version, 
+      CircleCI can comment on the merged PR with the final production version.
+      If you want contributors to see a message with the production version,
       please provide the username & token, and ensure the merge commit subject
       includes the PR number in default format.
-      i.e. 'Merge pull request #XX from some-branch [semver:patch]' 
+      i.e. 'Merge pull request #XX from some-branch [semver:patch]'
     type: boolean
 
   bot-user:
@@ -44,7 +44,7 @@ steps:
       - run:
           name: Grab Commit Info
           command: |
-            curl "https://circleci.com/api/v1.1/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}?circle-token=<< parameters.token-variable >>" > /tmp/build_info.txt            
+            curl "https://circleci.com/api/v1.1/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}?circle-token=<< parameters.token-variable >>" > /tmp/build_info.txt
       - run:
           name: Promote to prod
           command: |

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -1,0 +1,72 @@
+description: >
+  Uses the CLI to promote a dev version of an orb to the registry. 
+  This command supports Semantic Versioning support. In order to promote
+  the commit subject must include the `[semver:FOO]` pattern.
+  i.e. 'Merge pull request #XX from some-branch [semver:minor]' 
+
+parameters:
+  dev-version:
+    description: "A fully-qualified reference to a *development* orb. This takes the form <namespace>/<orb-name>@dev:<label>"
+    type: string
+
+  token-variable:
+    description: >
+      Name of env var containing your token. Pass this as a raw string such
+      as ORB_PUBLISHING_TOKEN. Do not paste the actual token into your
+      configuration. If omitted it's assumed the CLI has already been setup
+      with a valid token.
+    type: env_var_name
+    default: CIRCLE_TOKEN
+
+
+  add-pr-comment:
+    description: >
+      CircleCI can comment on the merged PR with the final production version. 
+      If you want contributors to see a message with the production version, 
+      please provide the username & token, and ensure the merge commit subject
+      includes the PR number in default format.
+      i.e. 'Merge pull request #XX from some-branch [semver:patch]' 
+    type: boolean
+
+  bot-user:
+    description: >
+      The GitHub user to post PR comment.
+    type: string
+    default: ""
+
+  bot-token:
+    description: >
+      The GitHub user's token to post PR comment.
+    type: string
+    default: ""
+
+steps:
+      - run:
+          name: Grab Commit Info
+          command: |
+            curl "https://circleci.com/api/v1.1/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}?circle-token=<< parameters.token-variable >>" > /tmp/build_info.txt            
+      - run:
+          name: Promote to prod
+          command: |
+            SEMVER_INCREMENT=`jq -r '.subject' /tmp/build_info.txt | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
+            if [ -z ${SEMVER_INCREMENT} ];then
+              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+              exit 1
+            fi
+            PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token << parameters.token-variable >>`
+            echo $PUBLISH_MESSAGE
+            ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+            echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
+      - when:
+          conditions: <<parameters.add-pr-comment>>
+            run:
+          name: Publish Prod version to PR
+          command: |
+            PR_NUMBER=`jq -r '.subject' /tmp/build_info.txt | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
+            echo "PR_NUMBER is ${PR_NUMBER}"
+            if [ "$PR_NUMBER" == "" ];then
+              echo "No pr found, do nothing. If this is a mistake, be sure your commit subject includes the pattern:"
+              echo "\tMerge pull request #XX from some-branch [semver:patch]"
+              exit 0
+            fi
+            curl -X POST -u "<<parameters.bot-user>>:<<parameters.bot-token>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -45,10 +45,6 @@ parameters:
 steps:
       - checkout
       - run:
-          name: Grab Commit Info
-          command: |
-            curl "https://circleci.com/api/v1.1/project/gh/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}?circle-token=<< parameters.token-variable >>" > /tmp/build_info.txt
-      - run:
           name: Promote to prod
           command: |
             SEMVER_INCREMENT=`git log -1 --pretty=%s. | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
@@ -66,7 +62,7 @@ steps:
             - run:
                 name: Publish Prod version to PR
                 command: |
-                  PR_NUMBER=`jq -r '.subject' /tmp/build_info.txt | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
+                  PR_NUMBER=`git log -1 --pretty=%s. | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
                   echo "PR_NUMBER is ${PR_NUMBER}"
                   if [ "$PR_NUMBER" == "" ];then
                     echo "No pr found, do nothing. If this is a mistake, be sure your commit subject includes the pattern:"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -18,7 +18,6 @@ parameters:
     type: env_var_name
     default: CIRCLE_TOKEN
 
-
   add-pr-comment:
     description: >
       CircleCI can comment on the merged PR with the final production version.
@@ -56,7 +55,7 @@ steps:
               echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
               exit 1
             fi
-            PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token << parameters.token-variable >>`
+            PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >>`
             echo $PUBLISH_MESSAGE
             ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
             echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -34,11 +34,14 @@ parameters:
     type: string
     default: ""
 
-  bot-token:
+  bot-token-variable:
     description: >
-      The GitHub user's token to post PR comment.
-    type: string
-    default: ""
+      Name of env var containing the GitHub token value of the GitHub user that
+      to be used for posting the PR comment. Pass this as a raw string such
+      as GITHUB_TOKEN. Do not paste the actual token into your
+      configuration.
+    type: env_var_name
+    default: PR_COMMENTER_GITHUB_TOKEN
 
 steps:
       - run:
@@ -70,4 +73,4 @@ steps:
                     echo "\tMerge pull request #XX from some-branch [semver:patch]"
                     exit 0
                   fi
-                  curl -X POST -u "<<parameters.bot-user>>:<<parameters.bot-token>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"
+                  curl -X POST -u "<<parameters.bot-user>>:$<<parameters.bot-token-variable>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -59,7 +59,7 @@ steps:
       - run:
           name: Promote to prod
           command: |
-            SEMVER_INCREMENT=`git log -1 --pretty=%s. | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
+            SEMVER_INCREMENT=`git log -1 --pretty=%s. | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
             if [ -z ${SEMVER_INCREMENT} ];then
               echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, patch, or skip (to skip promotion)"
               exit 1

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -1,7 +1,8 @@
 description: >
   Uses the CLI to promote a dev version of an orb to the registry.
   This command supports Semantic Versioning support. In order to promote
-  the commit subject must include the `[semver:FOO]` pattern.
+  the commit subject must include the `[semver:FOO]` pattern,
+  where FOO is major, minor, patch, or skip (to skip promotion).
   i.e. 'Merge pull request #XX from some-branch [semver:minor]'
 
 parameters:
@@ -49,13 +50,17 @@ steps:
           command: |
             SEMVER_INCREMENT=`git log -1 --pretty=%s. | sed -En 's/.*\[semver:(major|minor|patch)\].*/\1/p'`
             if [ -z ${SEMVER_INCREMENT} ];then
-              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, or patch"
+              echo "Merge commit did not indicate which SemVer increment to make. Please ammend commit with [semver:FOO] where FOO is major, minor, patch, or skip (to skip promotion)"
               exit 1
-            fi
-            PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >>`
-            echo $PUBLISH_MESSAGE
-            ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
-            echo "export ORB_VERSION=\"${ORB_VERSION}\"" >> $BASH_ENV
+            elif [ "$SEMVER_INCREMENT" == "skip" ];then
+              echo "SEMVER in commit indicated to skip orb release"
+              echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
+              exit 0
+            else
+              PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >>`
+              echo $PUBLISH_MESSAGE
+              ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
+              echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
       - when:
           condition: <<parameters.add-pr-comment>>
           steps:
@@ -69,4 +74,4 @@ steps:
                     echo "\tMerge pull request #XX from some-branch [semver:patch]"
                     exit 0
                   fi
-                  curl -X POST -u "<<parameters.bot-user>>:$<<parameters.bot-token-variable>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"*Production* version of orb available for use - \`${ORB_VERSION}\`\"}"
+                  curl -X POST -u "<<parameters.bot-user>>:$<<parameters.bot-token-variable>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -28,9 +28,19 @@ parameters:
       i.e. 'Merge pull request #XX from some-branch [semver:patch]'
     type: boolean
 
+  pr-number-sed-expression:
+    description: >
+      Used to extract the PR number from the commit subject with sed.
+      The default value works with the default
+      GitHub PR merge commit subject.
+      Only applicable when add-pr-comment is set to true.
+    type: string
+    default: 's/Merge pull request #\([0-9]*\) from.*/\1/p'
+
   bot-user:
     description: >
       The GitHub user to post PR comment.
+      Only applicable when add-pr-comment is set to true.
     type: string
     default: ""
 
@@ -40,6 +50,7 @@ parameters:
       to be used for posting the PR comment. Pass this as a raw string such
       as GITHUB_TOKEN. Do not paste the actual token into your
       configuration.
+      Only applicable when add-pr-comment is set to true.
     type: env_var_name
     default: PR_COMMENTER_GITHUB_TOKEN
 
@@ -55,23 +66,22 @@ steps:
             elif [ "$SEMVER_INCREMENT" == "skip" ];then
               echo "SEMVER in commit indicated to skip orb release"
               echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
-              exit 0
             else
               PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.dev-version>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >>`
               echo $PUBLISH_MESSAGE
               ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
               echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+            fi
       - when:
           condition: <<parameters.add-pr-comment>>
           steps:
             - run:
                 name: Publish Prod version to PR
                 command: |
-                  PR_NUMBER=`git log -1 --pretty=%s. | sed -n 's/Merge pull request #\([0-9]*\) from.*/\1/p'`
+                  PR_NUMBER=`git log -1 --pretty=%s. | sed -n '<<parameters.pr-number-sed-expression>>'`
                   echo "PR_NUMBER is ${PR_NUMBER}"
                   if [ "$PR_NUMBER" == "" ];then
-                    echo "No pr found, do nothing. If this is a mistake, be sure your commit subject includes the pattern:"
-                    echo "\tMerge pull request #XX from some-branch [semver:patch]"
+                    echo "No pr found; do nothing. If this is a mistake, check if your PR commit message matches the <<parameters.pr-number-sed-expression>> sed expression."
                     exit 0
                   fi
                   curl -X POST -u "<<parameters.bot-user>>:$<<parameters.bot-token-variable>>" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${PR_MESSAGE}\"}"

--- a/src/commands/dev-promote-semver.yml
+++ b/src/commands/dev-promote-semver.yml
@@ -43,6 +43,7 @@ parameters:
     default: PR_COMMENTER_GITHUB_TOKEN
 
 steps:
+      - checkout
       - run:
           name: Grab Commit Info
           command: |

--- a/src/examples/orb-dev-workflows.yml
+++ b/src/examples/orb-dev-workflows.yml
@@ -94,9 +94,10 @@ usage:
                 only: /master-.*/
 
         # publish a semver version of the orb. relies on
-        # the commit subject containing the text "[semver:patch|minor|major]"
+        # the commit subject containing the text "[semver:patch|minor|major|skip]"
         # as that will determine whether a patch, minor or major
-        # version will be published.
+        # version will be published or if publishing should
+        # be skipped.
         # e.g. [semver:patch] will cause a patch version to be published.
         - orb-tools/dev-promote-prod:
             orb-name: your-namespace/your-orb

--- a/src/examples/orb-dev-workflows.yml
+++ b/src/examples/orb-dev-workflows.yml
@@ -93,40 +93,18 @@ usage:
               tags:
                 only: /master-.*/
 
-        # patch, minor, or major publishing, depending on which orb source
-        # files have been modified (that logic lives in the
-        # trigger-integration-workflow job's source)
+        # publish a semver version of the orb. relies on
+        # the commit subject containing the text "[semver:patch|minor|major]"
+        # as that will determine whether a patch, minor or major
+        # version will be published.
+        # e.g. [semver:patch] will cause a patch version to be published.
         - orb-tools/dev-promote-prod:
-            name: dev-promote-patch
             orb-name: your-namespace/your-orb
+            add-pr-comment: false
             requires:
               - integration-tests-master
             filters:
               branches:
                 ignore: /.*/
               tags:
-                only: /master-patch.*/
-
-        - orb-tools/dev-promote-prod:
-            name: dev-promote-minor
-            release: minor
-            orb-name: your-namespace/your-orb
-            requires:
-              - integration-tests-master
-            filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /master-minor.*/
-
-        - orb-tools/dev-promote-prod:
-            name: dev-promote-major
-            release: major
-            orb-name: your-namespace/your-orb
-            requires:
-              - integration-tests-master
-            filters:
-              branches:
-                ignore: /.*/
-              tags:
-                only: /master-major.*/
+                only: /master-.*/

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -107,7 +107,6 @@ steps:
               TAG="v$NEW_VERSION"
 
               git tag -a "$TAG" \
-                -m "<<parameters.release>>" \
                 -m "View this orb release in the orb registry:" \
                 -m "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>?version=$NEW_VERSION" \
                 -m "View this orb release using the CircleCI CLI:" \

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -102,6 +102,7 @@ steps:
       token-variable: <<parameters.publish-token-variable>>
       dev-version: <<parameters.orb-name>>@<<parameters.orb-ref>>
       add-pr-comment: <<parameters.add-pr-comment>>
+      pr-number-sed-expression: <<parameters.pr-number-sed-expression>>
       bot-user: <<parameters.bot-user>>
       bot-token-variable: <<parameters.bot-token-variable>>
 

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -36,10 +36,20 @@ parameters:
       includes the PR number in default format.
       i.e. 'Merge pull request #XX from some-branch [semver:patch]'
 
+  pr-number-sed-expression:
+    description: >
+      Used to extract the PR number from the commit subject with sed.
+      The default value works with the default
+      GitHub PR merge commit subject.
+      Only applicable when add-pr-comment is set to true.
+    type: string
+    default: 's/Merge pull request #\([0-9]*\) from.*/\1/p'
+
   bot-user:
     type: string
     description: >
       The GitHub user to post PR comment.
+      Only applicable when add-pr-comment is set to true.
     default: ""
 
   bot-token-variable:
@@ -48,6 +58,7 @@ parameters:
       to be used for posting the PR comment. Pass this as a raw string such
       as GITHUB_TOKEN. Do not paste the actual token into your
       configuration.
+      Only applicable when add-pr-comment is set to true.
     type: env_var_name
     default: PR_COMMENTER_GITHUB_TOKEN
 

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -5,13 +5,6 @@ description: >
 executor: cli/default
 
 parameters:
-  release:
-    type: enum
-    default: patch
-    enum: [patch, minor, major]
-    description: >
-      What type of release to publish (patch, minor, major)?
-
   publish-token-variable:
     type: env_var_name
     default: CIRCLE_TOKEN
@@ -30,6 +23,27 @@ parameters:
       Dev:reference to promote to a production release, defaults to
       'dev:${CIRCLE_SHA1:0:7}' (evaluates to the first 7
       characters of the job's commit hash)
+
+  add-pr-comment:
+    type: boolean
+    description: >
+      CircleCI can comment on the merged PR with the final production version. 
+      If you want contributors to see a message with the production version, 
+      please provide the username & token, and ensure the merge commit subject
+      includes the PR number in default format.
+      i.e. 'Merge pull request #XX from some-branch [semver:patch]' 
+
+  bot-user:
+    type: string
+    description: >
+      The GitHub user to post PR comment.
+    default: ""
+
+  bot-token:
+    type: string
+    description: >
+      The GitHub user's token to post PR comment.
+    default: ""
 
   publish-version-tag:
     type: boolean
@@ -67,16 +81,12 @@ steps:
       steps:
         - checkout
 
-  - run:
-      name: promote dev orb to production/semantic release
-      command: |
-        circleci orb publish promote \
-          <<parameters.orb-name>>@<<parameters.orb-ref>> \
-          <<parameters.release>> --token \
-          $<<parameters.publish-token-variable>>
-
-        echo "View this orb release in the orb registry:"
-        echo "https://circleci.com/orbs/registry/orb/<<parameters.orb-name>>"
+  - dev-promote-semver:
+      token-variable: <<parameters.publish-token-variable>>
+      dev-version: <<parameters.orb-name>>@<<parameters.orb-ref>>
+      add-pr-comment: <<parameters.add-pr-comment>>
+      bot-user: <<parameters.bot-user>>
+      bot-token: <<parameters.bot-token>>
 
   - when:
       condition: <<parameters.publish-version-tag>>

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -1,5 +1,8 @@
 description: >
   Promote a dev version of an orb to a semantic production release.
+  In order to promote the orb, the commit subject must include the `[semver:FOO]`
+  pattern, where FOO is major, minor, patch, or skip (to skip promotion).
+  i.e. 'Merge pull request #XX from some-branch [semver:minor]'
   Designed to run at the conclusion of an integration-testing workflow.
 
 executor: cli/default

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -27,11 +27,11 @@ parameters:
   add-pr-comment:
     type: boolean
     description: >
-      CircleCI can comment on the merged PR with the final production version. 
-      If you want contributors to see a message with the production version, 
+      CircleCI can comment on the merged PR with the final production version.
+      If you want contributors to see a message with the production version,
       please provide the username & token, and ensure the merge commit subject
       includes the PR number in default format.
-      i.e. 'Merge pull request #XX from some-branch [semver:patch]' 
+      i.e. 'Merge pull request #XX from some-branch [semver:patch]'
 
   bot-user:
     type: string

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -39,11 +39,14 @@ parameters:
       The GitHub user to post PR comment.
     default: ""
 
-  bot-token:
-    type: string
+  bot-token-variable:
     description: >
-      The GitHub user's token to post PR comment.
-    default: ""
+      Name of env var containing the GitHub token value of the GitHub user that
+      to be used for posting the PR comment. Pass this as a raw string such
+      as GITHUB_TOKEN. Do not paste the actual token into your
+      configuration.
+    type: env_var_name
+    default: PR_COMMENTER_GITHUB_TOKEN
 
   publish-version-tag:
     type: boolean
@@ -86,7 +89,7 @@ steps:
       dev-version: <<parameters.orb-name>>@<<parameters.orb-ref>>
       add-pr-comment: <<parameters.add-pr-comment>>
       bot-user: <<parameters.bot-user>>
-      bot-token: <<parameters.bot-token>>
+      bot-token-variable: <<parameters.bot-token-variable>>
 
   - when:
       condition: <<parameters.publish-version-tag>>


### PR DESCRIPTION
This would be a [semver:major] change I think.

Rather than hard-coding the major,minor, patch increment, it will be
deciphered by the commit message, expecting the form `[semver:FOO]` in the subject.

This is major change because users will get a failure message if they do
not include that in the commit to a branch using the dev-promote job or command.

Optionally the prod version can be published by a bot back to GitHub PR. This is included because it uses the output of the promote command, but could be refactored into its own command.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
