### PR TITLE
[semver:minor] Use permissions checks for bats install

### DIFF
--- a/src/commands/install-bats.yml
+++ b/src/commands/install-bats.yml
@@ -12,8 +12,18 @@ steps:
           exit 1
         fi
 
+        if [[ $EUID == 0 ]]; then
+          export SUDO=""
+        else
+          export SUDO="sudo"
+          if ! which sudo > /dev/null; then
+            echo "root access is required - install sudo or run as root"
+            exit 1
+          fi
+        fi
+
         cd bats
-        sudo ./install.sh /usr/local || \
-          ./install.sh /usr/local
+        $SUDO ./install.sh /usr/local
         cd ..
         rm -rf bats
+        bats --version


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

A more detailed error message and extended error checking instead of blindly falling back to a second approach

### Description

* Replace the blind fallback to trying without sudo with a more complete check whether it is required to use sudo.
* Throw an error if required permissions to run `install.sh` are not available.
* validate bats installation by executing it