### PR TITLE
change resource_class from small to medium

### DIFF
--- a/src/executors/node-cci.yml
+++ b/src/executors/node-cci.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   resource-class:
     type: enum
-    default: small
+    default: medium
     enum: [small, medium, medium+, large, xlarge]
 
   tag:


### PR DESCRIPTION
free customers are unable to utilize `resource_class: small` therefore are blocked due to `free-plan-resource-class-unavailable`, changing `resource_class: medium` will allow free customers to utilize the orb

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

free customers are unable to utilize the `resource_class` key and therefore are blocked due to the error `free-plan-resource-class-unavailable`, changing `resource_class: medium` will allow free customers to utilize this orb


### Description

change default `resource_class` from `small` to `medium`
