### PR TITLE
Add possibility for custom git user name/email config #61

### DIFF
--- a/src/commands/configure-git.yml
+++ b/src/commands/configure-git.yml
@@ -1,0 +1,32 @@
+description: >
+  Sets mandatory git config fields to allow creating and pushing of tags.
+  If not set it will default to details from the VCS system, composed from the $CIRCLE_USERNAME variable.
+  If both $GIT_CONFIG_USER_NAME and $GIT_CONFIG_USER_EMAIL is set, they will be used instead.
+
+parameters:
+  git-config-user-name:
+    description: >
+      Set both GIT_CONFIG_USER_NAME and GIT_CONFIG_USER_EMAIL environment variables in order to override the default
+      user.name and user.email the git client is configured with. This parameter should not be changed.
+    type: env_var_name
+    default: GIT_CONFIG_USER_NAME
+
+  git-config-user-email:
+    description: >
+      Set both GIT_CONFIG_USER_NAME and GIT_CONFIG_USER_EMAIL environment variables in order to override the default
+      user.name and user.email the git client is configured with. This parameter should not be changed.
+    type: env_var_name
+    default: GIT_CONFIG_USER_EMAIL
+
+steps:
+  - run:
+      name: git config
+      command: |
+        if [ -z "$GIT_CONFIG_USER_NAME" ] || [ -z "$GIT_CONFIG_USER_EMAIL" ]; then
+          # No user name or email set, default to CIRCLE_USERNAME-based identifiers
+          git config --global user.name "$CIRCLE_USERNAME"
+          git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
+        else
+          git config --global user.name ${<< parameters.git-config-user-name >>}
+          git config --global user.email ${<< parameters.git-config-user-email >>}
+        fi

--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -85,11 +85,11 @@ steps:
             fingerprints:
               - <<parameters.ssh-fingerprints>>
 
+        - configure-git
+
         - run:
-            name: git config
+            name: construct/push git integration tag
             command: |
-              git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-              git config --global user.name "$CIRCLE_USERNAME"
 
               # construct/push new tag
               NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')

--- a/src/jobs/trigger-integration-workflow.yml
+++ b/src/jobs/trigger-integration-workflow.yml
@@ -128,11 +128,7 @@ steps:
             fingerprints:
               - <<parameters.ssh-fingerprints>>
 
-  - run:
-      name: git config
-      command: |
-        git config --global user.email "$CIRCLE_USERNAME@users.noreply.github.com"
-        git config --global user.name "$CIRCLE_USERNAME"
+  - configure-git
 
   - when:
       condition: <<parameters.use-git-diff>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Follow-up from https://github.com/CircleCI-Public/orb-tools-orb/issues/61

### Description

Extracting a command for setting git config and enabling custom git config, with fallback to todays values. Backwards compatible.

I checked the "examples and README" part of the checklist as this is a minor change. But as I propose in my issue #61 this might also be added as parameters to the jobs that use it, and then it would also show up as an option on the orb registry page.

I'll make appropriate changes to the PR if needed.