### PR TITLE
Remove unused parameter `cleanup-tags` in dev-promote-prod job

### DIFF
--- a/src/jobs/dev-promote-prod.yml
+++ b/src/jobs/dev-promote-prod.yml
@@ -38,14 +38,6 @@ parameters:
       Push a git tag describing the release that was just published? If `true`,
       make sure to pass SSH fingerprints, as well
 
-  cleanup-tags:
-    type: boolean
-    default: false
-    description: >
-      After publishing a version tag for a successful orb deployment, clean
-      up older tags? Use the `cleanup-tags-pattern` parameter to specify
-      which tags should be removed
-
   cleanup-tags-pattern:
     type: string
     default: "master*"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

None.

### Description

I believe the unused parameter should be removed. :)
