### PR TITLE
Fix parameter expansion on check-env-var-param command

### DIFF
--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -41,7 +41,7 @@ steps:
           IFS="," read -ra PARAMS \<<< "<<parameters.param>>"
 
           for i in "${PARAMS[@]}"; do
-            if [[ -z "${i}" ]]; then
+            if [[ -z "${!i}" ]]; then
               echo "ERROR: Missing environment variable {i}" >&2
 
               if [[ -n "<<parameters.error-message>>" ]]; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The `check-env-var-param` command was not working as expected.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

In order to evaluate whether a string is defined as a variable, you'll need to use an indirect shell [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html):

> The basic form of parameter expansion is ${parameter}. The value of parameter is substituted.
>
> If the first character of parameter is an exclamation point (!), it introduces a level of variable indirection. Bash uses the value of the variable formed from the rest of parameter as the name of the variable; this variable is then expanded and that value is used in the rest of the substitution, rather than the value of parameter itself.
