### PR TITLE
Always skip tag publishing when semver increment is "skip" or not indicated [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,10 @@ version: 2.1
 
 orbs:
   cli: circleci/circleci-cli@0.1
-  # Temporarily use dev version in order to make use of
-  # the new features of the dev orb
-  orb-tools: circleci/orb-tools@dev:newworkflow
+  orb-tools: circleci/orb-tools@9.0
   orb-tools-alpha: circleci/orb-tools@<<pipeline.parameters.dev-orb-version>>
   queue: eddiewebb/queue@1.1.2
+  jq: circleci/jq@1.9.1
 
 parameters:
   run-integration-tests:
@@ -17,6 +16,27 @@ parameters:
     default: "dev:alpha"
 
 commands:
+  set-up-test-repository:
+    parameters:
+      segment:
+        description: >
+          The semver segment to increment 'major' or 'minor' or 'patch'
+        type: enum
+        enum: [major, minor, patch, skip, none]
+        default: patch
+    steps:
+      - orb-tools-alpha/configure-git
+      - run:
+          name: Set up test repository
+          command: |
+            cd ..
+            rm -rf project
+            mkdir project
+            cd project
+            git init
+            echo "test" > test
+            git add . && git commit -am "Merge pull request #99TEST from dummy-branch [semver:<<parameters.segment>>]"
+
   check-pr-message:
     parameters:
       orb-name:
@@ -88,17 +108,8 @@ jobs:
     steps:
       - checkout
       - cli/install
-      - orb-tools-alpha/configure-git
-      - run:
-          name: Set up test repository
-          command: |
-            cd ..
-            rm -rf project
-            mkdir project
-            cd project
-            git init
-            echo "test" > test
-            git add . && git commit -am "Merge pull request #99TEST from dummy-branch [semver:<<parameters.segment>>]"
+      - set-up-test-repository:
+          segment: <<parameters.segment>>
       - orb-tools-alpha/dev-promote-from-commit-subject:
           checkout: false
           orb-name: sandbox/orb-tools
@@ -139,16 +150,13 @@ jobs:
           bot-user: cpe-bot
           bot-token-variable: GHI_TOKEN
           required-branch: $CIRCLE_BRANCH
+          # Make it unmatchable to avoid an actual PR being commented on
+          pr-number-sed-expression: 's/Merge pull request #\([0-9]*TEST\) from.*/\1/p'
       - check-pr-message:
           orb-name: sandbox/orb-tools
           expect-orb-to-be-published: true
 
 # yaml anchor filters
-prod-deploy_requires: &prod-deploy_requires
-  [
-    test-promote-from-git-tag
-  ]
-
 requires_commands: &requires_commands
   [
     test-commands-alpine,
@@ -225,7 +233,9 @@ workflows:
           name: test-commands-node
           executor: orb-tools-alpha/node
           context: orb-publishing
-          pre-steps: [run: sleep 2]
+          pre-steps:
+            - run: sleep 2
+            - jq/install
           segment: minor
 
       - test-commands:
@@ -313,7 +323,45 @@ workflows:
             - test-promote-from-commit-subject-semver-skip
             - test-promote-from-commit-subject-semver-none
 
-      # semver publishing
+      - orb-tools-alpha/dev-promote-prod-from-commit-subject:
+          name: test-publish-tags-skipped-on-semver-skip
+          checkout: false
+          orb-name: sandbox/orb-tools
+          fail-if-semver-not-indicated: false
+          add-pr-comment: true
+          bot-user: cpe-bot
+          bot-token-variable: GHI_TOKEN
+          pr-number-sed-expression: 's/Merge pull request #\([0-9]*TEST\) from.*/\1/p'
+          publish-version-tag: true
+          # use invalid fingerprints to make the job fail if it doesn't skip tag publishing
+          ssh-fingerprints: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+          pre-steps:
+            - checkout
+            - set-up-test-repository:
+                segment: "skip"
+          requires:
+            - test-promote-from-git-tag
+
+      - orb-tools-alpha/dev-promote-prod-from-commit-subject:
+          name: test-publish-tags-skipped-on-missing-semver
+          checkout: false
+          orb-name: sandbox/orb-tools
+          fail-if-semver-not-indicated: false
+          add-pr-comment: true
+          bot-user: cpe-bot
+          bot-token-variable: GHI_TOKEN
+          pr-number-sed-expression: 's/Merge pull request #\([0-9]*TEST\) from.*/\1/p'
+          publish-version-tag: true
+          # use invalid fingerprints to make the job fail if it doesn't skip tag publishing
+          ssh-fingerprints: 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+          pre-steps:
+            - checkout
+            - set-up-test-repository:
+                segment: "none"
+          requires:
+            - test-promote-from-git-tag
+
+      # Actually publish the orb
       - orb-tools/dev-promote-prod-from-commit-subject:
           name: dev-promote-semver
           add-pr-comment: true
@@ -324,7 +372,9 @@ workflows:
           orb-name: circleci/orb-tools
           publish-version-tag: true
           ssh-fingerprints: 33:d9:6e:a7:b2:ba:eb:90:7b:7a:dc:90:36:e1:b6:e0
-          requires: *prod-deploy_requires
+          requires:
+            - test-publish-tags-skipped-on-semver-skip
+            - test-publish-tags-skipped-on-missing-semver
           filters:
             branches:
               only: master

--- a/src/commands/dev-promote-from-commit-subject.yml
+++ b/src/commands/dev-promote-from-commit-subject.yml
@@ -89,6 +89,7 @@ steps:
         COMMIT_SUBJECT=`git log -1 --pretty=%s.`
         SEMVER_INCREMENT=`echo ${COMMIT_SUBJECT} | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p'`
         echo "Commit subject: ${COMMIT_SUBJECT}"
+        echo "export SEMVER_INCREMENT=\"$SEMVER_INCREMENT\""  >> $BASH_ENV
         if [ -z ${SEMVER_INCREMENT} ];then
           echo "Commit subject did not indicate which SemVer increment to make."
           echo "To publish orb, you can ammend the commit or push another commit with [semver:FOO] in the subject where FOO is major, minor, patch."

--- a/src/commands/dev-promote-from-commit-subject.yml
+++ b/src/commands/dev-promote-from-commit-subject.yml
@@ -107,6 +107,7 @@ steps:
           echo $PUBLISH_MESSAGE
           ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
           echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV
+          echo "export ORB_VERSION=\"$ORB_VERSION\"" >> $BASH_ENV
         fi
   - when:
       condition: <<parameters.add-pr-comment>>

--- a/src/jobs/dev-promote-prod-from-commit-subject.yml
+++ b/src/jobs/dev-promote-prod-from-commit-subject.yml
@@ -118,7 +118,7 @@ steps:
               if [ -z "${ORB_VERSION}" ] || [ -z "${SEMVER_INCREMENT}" ] || [ "${SEMVER_INCREMENT}" == "skip" ]; then
                 echo "Release tags will not be published."
                 echo "Reason: \"skip\" or no semver increment was indicated, or the orb was not published."
-                circleci step halt
+                circleci step halt --skip-update-check
               fi
 
         - add_ssh_keys:

--- a/src/jobs/dev-promote-prod-from-commit-subject.yml
+++ b/src/jobs/dev-promote-prod-from-commit-subject.yml
@@ -119,6 +119,11 @@ steps:
         - run:
             name: construct/push git release tag
             command: |
+              if [ -z "${SEMVER_INCREMENT}" ] || [ "${SEMVER_INCREMENT}" == "skip" ]; then
+                echo "Indicated semver increment was: ${SEMVER_INCREMENT}"
+                echo "Release tags will not be pushed because either \"skip\" or no semver increment was indicated"
+                exit 0
+              fi
 
               # construct/push new tag
               NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')

--- a/src/jobs/dev-promote-prod-from-commit-subject.yml
+++ b/src/jobs/dev-promote-prod-from-commit-subject.yml
@@ -110,6 +110,17 @@ steps:
   - when:
       condition: <<parameters.publish-version-tag>>
       steps:
+        - run:
+            name: Check if release tags should be published
+            command: |
+              echo "Indicated semver increment was: ${SEMVER_INCREMENT}"
+              echo "Version of orb published: ${ORB_VERSION}"
+              if [ -z "${ORB_VERSION}" ] || [ -z "${SEMVER_INCREMENT}" ] || [ "${SEMVER_INCREMENT}" == "skip" ]; then
+                echo "Release tags will not be published."
+                echo "Reason: \"skip\" or no semver increment was indicated, or the orb was not published."
+                circleci step halt
+              fi
+
         - add_ssh_keys:
             fingerprints:
               - <<parameters.ssh-fingerprints>>
@@ -119,14 +130,8 @@ steps:
         - run:
             name: construct/push git release tag
             command: |
-              if [ -z "${SEMVER_INCREMENT}" ] || [ "${SEMVER_INCREMENT}" == "skip" ]; then
-                echo "Indicated semver increment was: ${SEMVER_INCREMENT}"
-                echo "Release tags will not be pushed because either \"skip\" or no semver increment was indicated"
-                exit 0
-              fi
-
               # construct/push new tag
-              NEW_VERSION=$(circleci orb info <<parameters.orb-name>> | grep Latest | sed -E 's|Latest: <<parameters.orb-name>>@||')
+              NEW_VERSION=$(echo ${ORB_VERSION}| sed -E 's|<<parameters.orb-name>>@||')
 
               TAG="v$NEW_VERSION"
 

--- a/src/jobs/dev-promote-prod-from-commit-subject.yml
+++ b/src/jobs/dev-promote-prod-from-commit-subject.yml
@@ -118,7 +118,7 @@ steps:
               if [ -z "${ORB_VERSION}" ] || [ -z "${SEMVER_INCREMENT}" ] || [ "${SEMVER_INCREMENT}" == "skip" ]; then
                 echo "Release tags will not be published."
                 echo "Reason: \"skip\" or no semver increment was indicated, or the orb was not published."
-                circleci step halt --skip-update-check
+                circleci step halt
               fi
 
         - add_ssh_keys:


### PR DESCRIPTION
This PR resolves https://github.com/CircleCI-Public/orb-tools-orb/issues/76 . Even when `publish-tag` is set to `true` , tag publishing should be skipped when the semver increment is `skip` or not indicated. Additionally, the orb version number used for tag publishing is now obtained in a more accurate manner.

There are also other changes in the PR, which don't affect orb behavior:
- Update version of `orb-tools` orb used in build
- Fix the build; it is now using a newer version of the `circleci-cli` orb which requires `jq` to be installed, causing the `test-commands-node` job to fail as that image doesn't come with `jq`.
- Fix the  "test-promote-from-git-tag" integration test (see [CIRCLE-23282])

[CIRCLE-23282]: https://circleci.atlassian.net/browse/CIRCLE-23282