### PR TITLE
Add --skip-update-check flag to the circleci cli commands [semver:patch]

### DIFF
--- a/src/commands/dev-promote-from-commit-subject.yml
+++ b/src/commands/dev-promote-from-commit-subject.yml
@@ -103,7 +103,7 @@ steps:
           echo "SEMVER in commit indicated to skip orb release"
           echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:skip] in commit message.\""  >> $BASH_ENV
         else
-          PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.orb-name>>@<<parameters.orb-ref>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >>`
+          PUBLISH_MESSAGE=`circleci orb publish promote <<parameters.orb-name>>@<<parameters.orb-ref>> ${SEMVER_INCREMENT} --token $<< parameters.token-variable >> --skip-update-check`
           echo $PUBLISH_MESSAGE
           ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
           echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV

--- a/src/commands/dev-promote-from-git-tag.yml
+++ b/src/commands/dev-promote-from-git-tag.yml
@@ -145,7 +145,8 @@ steps:
           PUBLISH_MESSAGE=`circleci orb publish promote \
             <<parameters.orb-name>>@<<parameters.orb-ref>> \
             ${RELEASE_TYPE} --token \
-            ${CIRCLE_TOKEN}`
+            ${CIRCLE_TOKEN} \
+            --skip-update-check`
             echo $PUBLISH_MESSAGE
           ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')
           echo "export PR_MESSAGE=\"BotComment: *Production* version of orb available for use - \\\`${ORB_VERSION}\\\`\"" >> $BASH_ENV

--- a/src/commands/increment.yml
+++ b/src/commands/increment.yml
@@ -37,4 +37,4 @@ steps:
         << parameters.orb-path >>
         << parameters.orb-ref >>
         << parameters.segment >>
-        <<# parameters.token-variable >>--token $<< parameters.token-variable >> <</ parameters.token-variable >>
+        <<# parameters.token-variable >>--token $<< parameters.token-variable >> <</ parameters.token-variable >> --skip-update-check

--- a/src/commands/local-test-build.yml
+++ b/src/commands/local-test-build.yml
@@ -36,7 +36,7 @@ steps:
 
   - run:
       name: compile test config
-      command: circleci config process uncompiled-config.yml > config.yml
+      command: circleci config process --skip-update-check uncompiled-config.yml > config.yml
 
   - run:
       name: run test job locally

--- a/src/commands/pack.yml
+++ b/src/commands/pack.yml
@@ -22,4 +22,4 @@ steps:
   - run:
       name: "Pack << parameters.source>> to << parameters.destination >>"
       command: |
-        circleci config pack << parameters.source >> > << parameters.destination >>
+        circleci config pack --skip-update-check << parameters.source >> > << parameters.destination >>

--- a/src/commands/publish.yml
+++ b/src/commands/publish.yml
@@ -28,5 +28,5 @@ steps:
         Publish orb at << parameters.orb-path >> to << parameters.orb-ref >>
         NOTE: this currently assumes you are publishing to the registry at circleci.com
       command: >
-        circleci orb publish << parameters.orb-path >> << parameters.orb-ref >>
+        circleci orb publish --skip-update-check << parameters.orb-path >> << parameters.orb-ref >>
         <<# parameters.token-variable >>--token $<< parameters.token-variable >> <</ parameters.token-variable >>

--- a/src/commands/validate.yml
+++ b/src/commands/validate.yml
@@ -10,4 +10,4 @@ parameters:
 steps:
   - run:
       name: "Validate whether this is a well-formed orb."
-      command: circleci orb validate << parameters.orb-path >>
+      command: circleci orb --skip-update-check validate << parameters.orb-path >>


### PR DESCRIPTION
This avoids calling the GitHub Releases API to do a check for updates, and helps avoid rate limiting.
