### PR TITLE
fix typo in check-env-var-param.yml

### DIFF
--- a/src/commands/check-env-var-param.yml
+++ b/src/commands/check-env-var-param.yml
@@ -14,7 +14,7 @@ parameters:
       Comma-separated list of `env_var_name`-type values; all will be
       checked to ensure they are defined. Designed to be called at the
       beginning of an orb job or command, with a value like the following:
-      `<<parameters.foo>>,<<parameters.bar>>,<<parameters.baz>`, etc.
+      `<<parameters.foo>>,<<parameters.bar>>,<<parameters.baz>>`, etc.
 
   error-message:
     type: string


### PR DESCRIPTION
fix typo.
<<parameters.baz> -> <<parameters.baz>>

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
