### PR TITLE
Fix typo in dev-promote-from-commit-subject.yml

### DIFF
--- a/src/commands/dev-promote-from-commit-subject.yml
+++ b/src/commands/dev-promote-from-commit-subject.yml
@@ -92,7 +92,7 @@ steps:
         echo "export SEMVER_INCREMENT=\"$SEMVER_INCREMENT\""  >> $BASH_ENV
         if [ -z ${SEMVER_INCREMENT} ];then
           echo "Commit subject did not indicate which SemVer increment to make."
-          echo "To publish orb, you can ammend the commit or push another commit with [semver:FOO] in the subject where FOO is major, minor, patch."
+          echo "To publish orb, you can amend the commit or push another commit with [semver:FOO] in the subject where FOO is major, minor, patch."
           echo "Note: To indicate intention to skip promotion, include [semver:skip] in the commit subject instead."
           if [ "<<parameters.fail-if-semver-not-indicated>>" == "true" ];then
             exit 1


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I found a typo when using `dev-promote-from-commit-subject`.

### Description

Fix typo in dev-promote-from-commit-subject.yml
