### PR TITLE
[semver:patch] Use the provided token-variable parameter

### DIFF
--- a/src/commands/dev-promote-from-git-tag.yml
+++ b/src/commands/dev-promote-from-git-tag.yml
@@ -145,7 +145,7 @@ steps:
           PUBLISH_MESSAGE=`circleci orb publish promote \
             <<parameters.orb-name>>@<<parameters.orb-ref>> \
             ${RELEASE_TYPE} --token \
-            ${CIRCLE_TOKEN} \
+            ${<<parameters.token-variable>>} \
             --skip-update-check`
             echo $PUBLISH_MESSAGE
           ORB_VERSION=$(echo $PUBLISH_MESSAGE | sed -n 's/Orb .* was promoted to `\(.*\)`.*/\1/p')


### PR DESCRIPTION
The token-variable is provided as a parameter but not used. Use the provided one, or the defined default if not

### Motivation, issues

The parameter provided to the command was not being used. As a result it was not possible to change the environment variable that the token should be read from. 

### Description

add the usage of the `token-variable` parameter to the generated command
