### PR TITLE
[semver:minor] Add orb pack option

### DIFF
--- a/src/commands/pack.yml
+++ b/src/commands/pack.yml
@@ -12,6 +12,11 @@ parameters:
     description: "Path including the filename to output the packed orb."
     type: string
     default: orb.yml
+    
+  use-orb-pack:
+    description: Setting this will use the new "orb pack" instead of "config pack"
+    type: boolean
+    default: false
 
 steps:
   - run:
@@ -22,4 +27,9 @@ steps:
   - run:
       name: "Pack << parameters.source>> to << parameters.destination >>"
       command: |
-        circleci config pack --skip-update-check << parameters.source >> > << parameters.destination >>
+        if [[ "<< parameters.use-orb-pack >>" == "true" ]]; then
+          circleci orb pack --skip-update-check << parameters.source >> > << parameters.destination >>
+        else
+          circleci config pack --skip-update-check << parameters.source >> > << parameters.destination >>
+        fi 
+        

--- a/src/commands/pack.yml
+++ b/src/commands/pack.yml
@@ -12,7 +12,7 @@ parameters:
     description: "Path including the filename to output the packed orb."
     type: string
     default: orb.yml
-  
+
   use-orb-pack:
     description: Setting this will use the new "orb pack" instead of "config pack"
     type: boolean

--- a/src/commands/pack.yml
+++ b/src/commands/pack.yml
@@ -12,7 +12,7 @@ parameters:
     description: "Path including the filename to output the packed orb."
     type: string
     default: orb.yml
-    
+  
   use-orb-pack:
     description: Setting this will use the new "orb pack" instead of "config pack"
     type: boolean
@@ -31,5 +31,4 @@ steps:
           circleci orb pack --skip-update-check << parameters.source >> > << parameters.destination >>
         else
           circleci config pack --skip-update-check << parameters.source >> > << parameters.destination >>
-        fi 
-        
+        fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This will let users use "include" in their syntax

### Description

Adds an option to use the be orb pack command instead of the config pack command
