### PR TITLE
[semver:patch] Remove references to outdated job

### DIFF
--- a/src/examples/full.yml
+++ b/src/examples/full.yml
@@ -13,7 +13,6 @@ usage:
   orb_prep_jobs: &orb_prep_jobs
     [
       orb-tools/lint,
-      orb-tools/shellcheck,
       orb-tools/pack
     ]
 
@@ -43,8 +42,6 @@ usage:
         # This `lint-pack_validate_publish-dev` workflow will run on any commit
         # Lint your YAML
         - orb-tools/lint
-        # Linting for BASH commands
-        - orb-tools/shellcheck
         # Pack the orb into a single file and validate the result.
         - orb-tools/pack
         # release dev version of orb, for testing & possible publishing.

--- a/src/examples/orb-dev-workflows-git-tag.yml
+++ b/src/examples/orb-dev-workflows-git-tag.yml
@@ -15,7 +15,6 @@ usage:
   orb_prep_jobs: &orb_prep_jobs
     [
       orb-tools/lint,
-      orb-tools/shellcheck,
       orb-tools/pack
     ]
 
@@ -58,8 +57,6 @@ usage:
         # This `lint-pack_validate_publish-dev` workflow will run on any commit
         # Lint your YAML
         - orb-tools/lint
-        # Linting for BASH commands
-        - orb-tools/shellcheck
         # Pack the orb into a single file and validate the result.
         - orb-tools/pack
         # release dev version of orb, for testing & possible publishing.

--- a/src/examples/orb-dev-workflows.yml
+++ b/src/examples/orb-dev-workflows.yml
@@ -22,7 +22,6 @@ usage:
   orb_prep_jobs: &orb_prep_jobs
     [
       orb-tools/lint,
-      orb-tools/shellcheck,
       orb-tools/pack
     ]
 
@@ -52,8 +51,6 @@ usage:
         # This `lint-pack_validate_publish-dev` workflow will run on any commit
         # Lint your YAML
         - orb-tools/lint
-        # Linting for BASH commands
-        - orb-tools/shellcheck
         # Pack the orb into a single file and validate the result.
         - orb-tools/pack
         # release dev version of orb, for testing & possible publishing.


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

This fixes #99 and removes references to the (now outdated) job `orb-tools/shellcheck` since it has moved into its own orb.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
