### PR TITLE
[semver:patch] use BOT_TOKEN instead of TOKEN

### DIFF
--- a/src/scripts/post-pr-comment.sh
+++ b/src/scripts/post-pr-comment.sh
@@ -4,4 +4,4 @@ if [ "$PR_NUMBER" == "" ];then
     echo "No pr found; do nothing. If this is a mistake, check if your PR commit message matches the $SED_EXP sed expression."
     exit 0
 fi
-curl -X POST -u "${BOT_USER}:${TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${COMMENT}\"}"
+curl -X POST -u "${BOT_USER}:${BOT_TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${COMMENT}\"}"


### PR DESCRIPTION
as this is how it is defined in https://github.com/CircleCI-Public/orb-tools-orb/blob/master/src/commands/post-pr-comment.yml

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- ~~All new jobs, commands, executors, parameters have descriptions~~
- ~~Examples have been added for any significant new features~~
- ~~README has been updated, if necessary~~

### Motivation, issues

When enabling the Github comment (see the `add-pr-comment` parameter in [dev-promote-from-commit-subject](https://circleci.com/developer/orbs/orb/circleci/orb-tools#commands-dev-promote-from-commit-subject)), the command saves the parameter as the `BOT_TOKEN` environment variable, the script however uses the `TOKEN` variable. This makes it impossible to use the `add-pr-comment: true` setting.

### Description

use BOT_TOKEN instead of TOKEN in post-pr-comment.sh
