### PR TITLE
[semver:patch] Fix job name in description

### DIFF
--- a/src/examples/orb-dev-workflows-git-tag.yml
+++ b/src/examples/orb-dev-workflows-git-tag.yml
@@ -1,5 +1,5 @@
 description: >
-  Use the lint, pack, publish-dev, and trigger-integration-workflow jobs
+  Use the lint, pack, publish-dev, and trigger-integration-tests-workflow jobs
   to lint a destructured orb's YAML source code, pack it into a single
   orb.yml file, release a @dev:${CIRCLE_SHA1:0:7} version of the orb, and trigger
   an integration testing workflow that will run against the new dev

--- a/src/examples/orb-dev-workflows.yml
+++ b/src/examples/orb-dev-workflows.yml
@@ -1,5 +1,5 @@
 description: >
-  Use the lint, pack, publish-dev, and trigger-integration-workflow jobs
+  Use the lint, pack, publish-dev, and trigger-integration-tests-workflow jobs
   to lint a destructured orb's YAML source code, pack it into a single
   orb.yml file, release a @dev:${CIRCLE_SHA1:0:7} version of the orb, and trigger
   an integration testing workflow that will run against the new dev


### PR DESCRIPTION
### Checklist

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues
When I read [this page](https://circleci.com/developer/orbs/orb/circleci/orb-tools) I noticed that the correct job names are different from the description.
