### PR TITLE
#77 - Default value for semver

### DIFF
--- a/src/commands/dev-promote-from-commit-subject.yml
+++ b/src/commands/dev-promote-from-commit-subject.yml
@@ -78,6 +78,15 @@ parameters:
       Whether to fail if the commit subject did not include [semver:patch|minor|major|skip]
     type: boolean
 
+  default-semver-increment:
+    description: >
+      Default increment to assume if the commit subject 
+      did not include [semver:patch|minor|major|skip].
+      The default values can only be patch, minor or major, 
+      otherwise being ignored.
+    type: string
+    default: ""
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -90,6 +99,7 @@ steps:
         ORB_REF: <<parameters.orb-ref>>
         TOKEN: "$<<parameters.token-variable>>"
         SHOULD_FAIL: <<parameters.fail-if-semver-not-indicated>>
+        DEFAULT_SEMVER_INCREMENT: "<<parameters.default-semver-increment>>"
       command: <<include(scripts/dev-promote-from-commit-subject.sh)>>
   - when:
       condition: <<parameters.add-pr-comment>>

--- a/src/scripts/dev-promote-from-commit-subject.sh
+++ b/src/scripts/dev-promote-from-commit-subject.sh
@@ -7,6 +7,10 @@ Setup() {
 GetIncrement() {
     SEMVER_INCREMENT=$(echo "${COMMIT_SUBJECT}" | sed -En 's/.*\[semver:(major|minor|patch|skip)\].*/\1/p')
     echo "Commit subject: ${COMMIT_SUBJECT}"
+    if [ -z "${SEMVER_INCREMENT}"  ]; then
+        echo "Commit subject did not indicate which SemVer increment to make. Will now assume the default one."
+        SEMVER_INCREMENT=$(echo "${DEFAULT_SEMVER_INCREMENT}" | sed -En 's/^(major|minor|patch)$/\1/p')
+    fi
     echo "export SEMVER_INCREMENT=\"$SEMVER_INCREMENT\""  >> "$BASH_ENV"
 }
 
@@ -19,7 +23,7 @@ PublishOrb() {
 
 CheckIncrement() {
     if [ -z "${SEMVER_INCREMENT}" ];then
-        echo "Commit subject did not indicate which SemVer increment to make."
+        echo "Commit subject did not indicate which SemVer increment to make and a default one was not set."
         echo "To publish orb, you can ammend the commit or push another commit with [semver:FOO] in the subject where FOO is major, minor, patch."
         echo "Note: To indicate intention to skip promotion, include [semver:skip] in the commit subject instead."
         if [ "$SHOULD_FAIL" == "true" ];then

--- a/src/tests/dev-promote-from-commit-subject.bats
+++ b/src/tests/dev-promote-from-commit-subject.bats
@@ -47,6 +47,28 @@ setup() {
 
 }
 
+@test 'Promote From Commit Subject 7: Test GetIncrement default to major' {
+    export COMMIT_SUBJECT="Test CircleCI Orb"
+    export DEFAULT_SEMVER_INCREMENT="major"
+    GetIncrement
+    grep -e 'SEMVER_INCREMENT="major"' $BASH_ENV
+}
+
+@test 'Promote From Commit Subject 7: Test GetIncrement default to minor' {
+    export COMMIT_SUBJECT="Test CircleCI Orb"
+    export DEFAULT_SEMVER_INCREMENT="minor"
+    GetIncrement
+    grep -e 'SEMVER_INCREMENT="minor"' $BASH_ENV
+}
+
+@test 'Promote From Commit Subject 7: Test GetIncrement default to patch' {
+    export COMMIT_SUBJECT="Test CircleCI Orb"
+    export DEFAULT_SEMVER_INCREMENT="patch"
+    GetIncrement
+    grep -e 'SEMVER_INCREMENT="patch"' $BASH_ENV
+}
+
+
 function teardown() {
     rm -rf .command_functions /tmp/BASH_ENV
 }


### PR DESCRIPTION
Adds new parameter to set a default value when the commit
does not contain [semver:<increment_type>] on the subject.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
In my team we are always forgetting to add the semver on the commit subject and this forces us to do a new commit just to bump it. I would prefer to fallback to patch if someone forget to add it. It seems that this is also requested by other people as well, as we can see in #77.
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
Adds a new parameter to set a default increment to be used if the commit subject does not contain the required expression [semver:(patch|minor|major|skip)] to increment the version.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
