### PR TITLE
[semver:patch] Ensure `fail-if-semver-not-indicated` parameter set to `true` is honored

### DIFF
--- a/src/scripts/dev-promote-from-commit-subject.sh
+++ b/src/scripts/dev-promote-from-commit-subject.sh
@@ -22,7 +22,7 @@ CheckIncrement() {
         echo "Commit subject did not indicate which SemVer increment to make."
         echo "To publish orb, you can ammend the commit or push another commit with [semver:FOO] in the subject where FOO is major, minor, patch."
         echo "Note: To indicate intention to skip promotion, include [semver:skip] in the commit subject instead."
-        if [ "$SHOULD_FAIL" == "true" ];then
+        if [ "$SHOULD_FAIL" == "1" ];then
             exit 1
         else
         echo "export PR_MESSAGE=\"BotComment: Orb publish was skipped due to [semver:patch|minor|major] not being included in commit message.\""  >> "$BASH_ENV"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
In the [`dev-promote-from-commit-subject` command's definition](https://circleci.com/developer/orbs/orb/circleci/orb-tools?version=10.0.3#commands-dev-promote-from-commit-subject), the function `CheckIncrement` relies on a conditional expression to decide whether or no to fail the build if the commit subject doesn't include a `SemVer` increment:

```
if [ "$SHOULD_FAIL" == "true" ];then
  exit 1
```
`SHOULD_FAIL` is defined as an environment variable of the related step:

`SHOULD_FAIL: <<parameters.fail-if-semver-not-indicated>>`

However, as the shell environment variable `SHOULD_FAIL` will only ever resolves as either:
- `1` (if `fail-if-semver-not-indicated` is set to `true`)

or

- `0` (if `fail-if-semver-not-indicated` is set to `false`)

the expression `[ "$SHOULD_FAIL" == "true" ]` will always return `false`, and therefore the `fail-if-semver-not-indicated` parameter set to `true` will never be honored.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Modify the aforementioned conditional expression so it references the relevant value of the environment variable, and allows `fail-if-semver-not-indicated` set to `true` to be honored.

Fixes #112