### PR TITLE
[semver:patch] Fix improperly dereferenced variable for GitHub

### DIFF
--- a/src/commands/post-pr-comment.yml
+++ b/src/commands/post-pr-comment.yml
@@ -40,7 +40,7 @@ steps:
       name: Post comment to GitHub pull request
       environment:
         BOT_USER: <<parameters.bot-user>>
-        BOT_TOKEN: "$<<parameters.bot-token-variable>>"
+        BOT_TOKEN: <<parameters.bot-token-variable>>
         COMMENT: <<parameters.comment>>
         SED_EXP: <<parameters.pr-number-sed-expression>>
       command: <<include(scripts/post-pr-comment.sh)>>

--- a/src/scripts/post-pr-comment.sh
+++ b/src/scripts/post-pr-comment.sh
@@ -4,4 +4,4 @@ if [ "$PR_NUMBER" == "" ];then
     echo "No pr found; do nothing. If this is a mistake, check if your PR commit message matches the $SED_EXP sed expression."
     exit 0
 fi
-curl -X POST -u "${BOT_USER}:${BOT_TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${COMMENT}\"}"
+curl -X POST -u "${BOT_USER}:${!BOT_TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments" -d "{\"body\":\"${COMMENT}\"}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
The variable handling for `BOT_TOKEN` was broken in the `post-pr-comment` command, when using this with `dev-promote-from-commit-subject` and parameter `add-pr-comment: true`, the step `Post comment to GitHub pull request` would show a failed curl api call:
```
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue-comment"
}
```
Traced this to the `BOT_TOKEN` environment variable not being dereferenced properly.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Removed the extraneous `$` prefix on the environment value; and added a bash dereference modifier (`${!`) to the script, tested (it works).  Not sure what the point of the interim `BOT_TOKEN` environment variable was at all, instead of simply passing the `<< parameter.bot-token-variable >>` right into the curl call, but I left it.
