### PR TITLE
[semver:minor] Add circleci-api-host and circleci-app-host params

### DIFF
--- a/src/commands/trigger-integration-tests-workflow.yml
+++ b/src/commands/trigger-integration-tests-workflow.yml
@@ -24,6 +24,18 @@ parameters:
     description: >
       Name of environment variable containing your personal CircleCI API token
 
+  circleci-api-host:
+    type: string
+    default: https://circleci.com
+    description: >
+      Host URL of CircleCI API
+
+  circleci-app-host:
+    type: string
+    default: https://app.circleci.com
+    description: >
+      Host URL of CircleCI Web UI
+
 steps:
   - when:
       condition: <<parameters.checkout>>
@@ -37,4 +49,6 @@ steps:
       environment:
         PARAM_MAP: '<<parameters.pipeline-param-map>>'
         TOKEN: "$<<parameters.token-variable>>"
+        CIRCLECI_API_HOST: <<parameters.circleci-api-host>>
+        CIRCLECI_APP_HOST: <<parameters.circleci-app-host>>
       command: <<include(scripts/trigger-integration-tests-workflow.sh)>>

--- a/src/jobs/trigger-integration-tests-workflow.yml
+++ b/src/jobs/trigger-integration-tests-workflow.yml
@@ -27,8 +27,22 @@ parameters:
     description: >
       Name of environment variable containing your personal CircleCI API token
 
+  circleci-api-host:
+    type: string
+    default: https://circleci.com
+    description: >
+      Host URL of CircleCI API
+
+  circleci-app-host:
+    type: string
+    default: https://app.circleci.com
+    description: >
+      Host URL of CircleCI Web UI
+
 steps:
   - trigger-integration-tests-workflow:
       checkout: <<parameters.checkout>>
       pipeline-param-map: '<<parameters.pipeline-param-map>>'
       token-variable: <<parameters.token-variable>>
+      circleci-api-host: <<parameters.circleci-api-host>>
+      circleci-app-host: <<parameters.circleci-app-host>>

--- a/src/scripts/trigger-integration-tests-workflow.sh
+++ b/src/scripts/trigger-integration-tests-workflow.sh
@@ -11,7 +11,7 @@ BuildParams() {
 
 DoCurl() {
     curl -u "${T}": -X POST --header "Content-Type: application/json" -d @pipelineparams.json \
-      "https://circleci.com/api/v2/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pipeline" -o /tmp/curl-result.txt
+      "${CIRCLECI_API_HOST}/api/v2/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pipeline" -o /tmp/curl-result.txt
 }
 
 Result() {
@@ -21,7 +21,7 @@ Result() {
         exit 1
     else
         echo "Pipeline triggered!"
-        echo "https://app.circleci.com/jobs/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/$(cat /tmp/curl-result.txt | jq -r .number)"
+        echo "${CIRCLECI_APP_HOST}/jobs/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/$(cat /tmp/curl-result.txt | jq -r .number)"
     fi
 }
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Hi, there.

I'm using CircleCI through CircleCI Server in my company. The `trigger-integration-tests-workflow` job has hardcoded the CircleCI API host URL and CircleCI Web App host URL, so I cannot change them. I've added a parameter that enables change them. Thank you.

### Description

1. add `circleci-api-host` param to `trigger-integration-tests-workflow` job and command
1. add `circleci-app-host` param to `trigger-integration-tests-workflow` job and command
1. use it in `trigger-integration-tests-workflow.sh`

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
