### PR TITLE
feat: Changes parameters to fix production publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ workflows:
       - orb-tools-alpha/publish:
           orb-name: circleci/orb-tools
           vcs-type: << pipeline.project.type >>
-          dev: true
           requires:
             [
               orb-tools-alpha/lint,

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ workflows:
       - orb-tools-alpha/publish:
           orb-name: circleci/orb-tools
           vcs-type: << pipeline.project.type >>
+          dev: true
           requires:
             [
               orb-tools-alpha/lint,

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,6 +20,7 @@ workflows:
       - orb-tools-alpha/publish:
           orb-name: circleci/orb-tools
           vcs-type: <<pipeline.project.type>>
+          pub-type: production
           requires:
             [orb-tools-alpha/lint, orb-tools-alpha/review, orb-tools-alpha/pack]
           context: orb-publisher

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,6 +23,7 @@ workflows:
           requires:
             [orb-tools-alpha/lint, orb-tools-alpha/review, orb-tools-alpha/pack]
           context: orb-publisher
+          github-token: GHI_TOKEN
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,5 +26,7 @@ workflows:
           context: orb-publisher
           github-token: GHI_TOKEN
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/src/examples/step1_lint-pack.yml
+++ b/src/examples/step1_lint-pack.yml
@@ -9,19 +9,32 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    orb-tools: circleci/orb-tools@11.0
-    shellcheck: circleci/shellcheck@3.0
+    orb-tools: circleci/orb-tools@11.1
+    shellcheck: circleci/shellcheck@3.1
 
   workflows:
     lint-pack:
       jobs:
-        - orb-tools/lint
-        - orb-tools/pack
-        - orb-tools/review
+        - orb-tools/lint:
+          filters:
+            tags:
+              only: /.*/
+        - orb-tools/pack:
+          filters:
+            tags:
+              only: /.*/
+        - orb-tools/review:
+          filters:
+            tags:
+              only: /.*/
         - shellcheck/check:
             exclude: SC2148,SC2038,SC2086,SC2002,SC2016
-        - orb-tools-/publish-dev:
+            filters:
+              tags:
+                only: /.*/
+        - orb-tools-/publish:
             orb-name: circleci/orb-tools
+            vcs-type: << pipeline.project.type >>
             requires:
               [
                 orb-tools/lint,
@@ -31,8 +44,14 @@ usage:
               ]
             # Use a context to hold your publishing token.
             context: publishing-context
+            filters:
+              tags:
+                only: /.*/
         # Triggers the next workflow in the Orb Development Kit.
         - orb-tools-/continue:
             pipeline-number: << pipeline.number >>
             vcs-type: << pipeline.project.type >>
-            requires: [orb-tools-/publish-dev]
+            requires: [orb-tools-/publish]
+            filters:
+              tags:
+                only: /.*/

--- a/src/examples/step2_test-deploy.yml
+++ b/src/examples/step2_test-deploy.yml
@@ -6,7 +6,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    orb-tools: circleci/orb-tools@11.0
+    orb-tools: circleci/orb-tools@11.1
     my-orb: namespace/my-orb@dev:<<pipeline.git.revision>>
   jobs:
     # Create a job to test the commands of your orbs.
@@ -33,12 +33,14 @@ usage:
               tags:
                 only: /.*/
         # Because our publishing job has a tag filter, we must also apply a filter to each job it depends on.
-        - orb-tools/publish-release:
+        - orb-tools/publish:
             orb-name: namespace/my-orb
+            pub-type: production
+            vcs-type: <<pipeline.project.type>>
             requires: [command-tests, my-orb/my-job]
             context: orb-publisher
             filters:
               tags:
-                only: /^v.*/
+                only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
               branches:
                 ignore: /.*/

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -1,8 +1,6 @@
 description: |
   Publish a new version of your orb.
-  This job will produce a development version of an orb by default or will produce a new production version if the $CIRCLE_TAG environment variable is set.
-  Push a new semantic version tag to the repository to publish a new production version of your orb.
-  To ignore tags and only produce development version of orbs, set "dev" to true.
+  This job will produce a development version of an orb by default or will produce a new production version if the $CIRCLE_TAG environment variable is , and the "pub-type" parameter is set to "production".
 
 executor: cli/default
 
@@ -42,10 +40,16 @@ parameters:
       For GitHub users, a $GITHUB_TOKEN environment variable must be set.
     type: boolean
     default: true
-  dev:
-    description: If enabled, tags will be ignored and only development versions will be published.
-    type: boolean
-    default: false
+  pub-type:
+    description: |
+      Select the publishing type. Available options are "dev" and "production".
+      If "production" is selected, the orb will be published to the orb registry only if the $CIRCLE_TAG environment variable is set. Publishing will be skipped otherwise.
+      If "dev" is selected, two tags will be created: "dev:alpha" and "dev:<SHA1>".
+    type: enum
+    enum:
+      - dev
+      - production
+    default: "dev"
 steps:
   - attach_workspace:
       at: <<parameters.orb-dir>>
@@ -55,7 +59,7 @@ steps:
         ORB_PARAM_ORB_PUB_TOKEN: <<parameters.circleci-token>>
         ORB_PARAM_ORB_NAME: <<parameters.orb-name>>
         ORB_PARAM_ORB_DIR: <<parameters.orb-dir>>
-        ORB_PARAM_DEV_ONLY: <<parameters.dev>>
+        ORB_PARAM_PUB_TYPE: <<parameters.pub-type>>
         PARAM_GH_TOKEN: <<parameters.github-token>>
       command: <<include(scripts/publish.sh)>>
   - when:
@@ -69,4 +73,3 @@ steps:
               ORB_PARAM_ORB_PUB_TOKEN: <<parameters.circleci-token>>
               PIPELINE_VCS_TYPE: <<parameters.vcs-type>>
             command: <<include(scripts/comment-pr.sh)>>
-

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -2,6 +2,7 @@ description: |
   Publish a new version of your orb.
   This job will produce a development version of an orb by default or will produce a new production version if the $CIRCLE_TAG environment variable is set.
   Push a new semantic version tag to the repository to publish a new production version of your orb.
+  To ignore tags and only produce development version of orbs, set "dev" to true.
 
 executor: cli/default
 
@@ -41,6 +42,10 @@ parameters:
       For GitHub users, a $GITHUB_TOKEN environment variable must be set.
     type: boolean
     default: true
+  dev:
+    description: If enabled, tags will be ignored and only development versions will be published.
+    type: boolean
+    default: false
 steps:
   - attach_workspace:
       at: <<parameters.orb-dir>>
@@ -50,6 +55,7 @@ steps:
         ORB_PARAM_ORB_PUB_TOKEN: <<parameters.circleci-token>>
         ORB_PARAM_ORB_NAME: <<parameters.orb-name>>
         ORB_PARAM_ORB_DIR: <<parameters.orb-dir>>
+        ORB_PARAM_DEV_ONLY: <<parameters.dev>>
         PARAM_GH_TOKEN: <<parameters.github-token>>
       command: <<include(scripts/publish.sh)>>
   - when:

--- a/src/scripts/comment-pr.sh
+++ b/src/scripts/comment-pr.sh
@@ -44,7 +44,7 @@ function mainGitHub() {
     echo "Authenticated as: $(isAuthenticatedGitHub | jq -r '.data.viewer.login')"
     FetchedPRData="$(getGithubPRFromCommit)"
     # Fetch the PR ID from the commit
-    if [ "$(echo "$FetchedPRData" | jq -e '.data.search.issueCount | length > 0')" ]; then
+    if [ "$(echo "$FetchedPRData" | jq -e '.data.search.issueCount | length > 0')" -gt 0 ]; then
       # PR Found
       PR_COUNT=$(echo "$FetchedPRData" | jq -e '.data.search.issueCount')
       echo "$PR_COUNT PR(s) found!"
@@ -59,6 +59,7 @@ function mainGitHub() {
       echo "It may be that the PR has not yet been created from this commit at the time of this build."
       echo "If you have recently created a PR, subsequent code pushes should properly identify the PR."
       echo "Skipping commenting..."
+      exit 0
     fi
 
   else

--- a/src/scripts/comment-pr.sh
+++ b/src/scripts/comment-pr.sh
@@ -44,7 +44,7 @@ function mainGitHub() {
     echo "Authenticated as: $(isAuthenticatedGitHub | jq -r '.data.viewer.login')"
     FetchedPRData="$(getGithubPRFromCommit)"
     # Fetch the PR ID from the commit
-    if [ "$(echo "$FetchedPRData" | jq -e '.data.search.issueCount | length > 0')" -gt 0 ]; then
+    if [ "$(echo "$FetchedPRData" | jq -e '.data.search.issueCount')" -gt 0 ]; then
       # PR Found
       PR_COUNT=$(echo "$FetchedPRData" | jq -e '.data.search.issueCount')
       echo "$PR_COUNT PR(s) found!"

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -49,7 +49,7 @@ function publishDevOrbs() {
 function orbPublish() {
   echo "Preparing to publish your orb."
   validateOrbPubToken
-  if [ -n "${CIRCLE_TAG}" ]; then
+  if [[ -n "${CIRCLE_TAG}" && "$ORB_PARAM_DEV_ONLY" -eq 0 ]]; then
     PUBLISH_PRODUCTION_ORB=true
     echo "Production release detected!"
     validateProdTag


### PR DESCRIPTION
Ran into an issue when publish orb tools 11, the tag was present so the prod version was published immediately before the tests. This new dev parameter allows the first publish job to _only_ publish dev tags.