### PR TITLE
fix: Follow home_url redirects for bats review

### DIFF
--- a/src/scripts/review.bats
+++ b/src/scripts/review.bats
@@ -89,7 +89,7 @@ setup() {
 	if [[ "${SKIPPED_REVIEW_CHECKS[*]}" =~ "RC007" || "$HOME_URL" == "null" ]]; then
 		skip
 	fi
-	HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" --retry 5 --retry-delay 5 "$HOME_URL")
+	HTTP_RESPONSE=$(curl -s -L -o /dev/null -w "%{http_code}" --retry 5 --retry-delay 5 "$HOME_URL")
 	if [[ "$HTTP_RESPONSE" -ne 200 ]]; then
 		echo
 		echo "Home URL: \"$HOME_URL\" is not reachable."


### PR DESCRIPTION
Ex: Nodejs `https://nodejs.org/` redirects to `https://nodejs.org/en/`, and does not initially respond with a 200 response. This might not be the best solution for all URL responses that could be considered valid.