### PR TITLE
fix to use configured pipeline api host

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -20,6 +20,12 @@ parameters:
     description: Path to the next config file to execute. By default, this will execute the "test-deploy" workflow.
     type: string
     default: .circleci/test-deploy.yml
+  circleci-api-host:
+    description: Host URL of CircleCI API. If you are using self-hosted CircleCI, this value should be set.
+    default: https://circleci.com
+  circleci-app-host:
+    description: Host URL of CircleCI Web UI. If you are using self-hosted CircleCI, this value should be set.
+    default: https://app.circleci.com
 
 steps:
   - checkout
@@ -29,4 +35,6 @@ steps:
         ORB_PARAM_CONTINUE_CONFIG_PATH: <<parameters.config-path>>
         PIPELINE_NUMBER: <<parameters.pipeline-number>>
         PIPELINE_VCS_TYPE: <<parameters.vcs-type>>
+        CIRCLECI_API_HOST: <<parameters.circleci-api-host>>
+        CIRCLECI_APP_HOST: <<parameters.circleci-app-host>>
       command: <<include(scripts/continue.sh)>>

--- a/src/scripts/continue.sh
+++ b/src/scripts/continue.sh
@@ -4,6 +4,12 @@ if [ -z "${CIRCLE_CONTINUATION_KEY}" ]; then
 	echo "This Job is designed to be used with the Orb Development Kit."
 	exit 1
 fi
+if [ -z "${CIRCLECI_API_HOST}" ]; then
+	echo "CIRCLECI_API_HOST is required."
+	echo "If you are using CircleCI Cloud, use default value or set https://circleci.com."
+	exit 1
+fi
+
 if ! command -v curl; then
 	echo "curl is required to use this command"
 	exit 1
@@ -33,8 +39,8 @@ jq -n \
 	-H "Content-Type: application/json" \
 	-H "Accept: application/json" \
 	--data @/tmp/circleci/continue_post.json \
-	"https://circleci.com/api/v2/pipeline/continue") -eq 200 ]]
+	"${CIRCLECI_API_HOST}/api/v2/pipeline/continue") -eq 200 ]]
 
 echo "Continuation successful!"
 echo "Your newly published development orb will now be tested in the next workflow."
-echo "View the full pipeline progress: https://app.circleci.com/pipelines/${PIPELINE_VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${PIPELINE_VCS_TYPE}/${PIPELINE_NUMBER}"
+echo "View the full pipeline progress: ${CIRCLECI_APP_HOST}/pipelines/${PIPELINE_VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${PIPELINE_VCS_TYPE}/${PIPELINE_NUMBER}"


### PR DESCRIPTION
Motivation is same with #117. 
Fixed URL make fail on self-hosted CircleCI .