### PR TITLE
fix: missing redirect for RC006

### DIFF
--- a/src/scripts/review.bats
+++ b/src/scripts/review.bats
@@ -75,7 +75,7 @@ setup() {
 		skip
 	fi
 	SOURCE_URL=$(yq '.display.source_url' "${REVIEW_TEST_DIR}/src/@orb.yml")
-	HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" --retry 5 --retry-delay 5 "$SOURCE_URL")
+	HTTP_RESPONSE=$(curl -s -L -o /dev/null -w "%{http_code}" --retry 5 --retry-delay 5 "$SOURCE_URL")
 	if [[ "$HTTP_RESPONSE" -ne 200 ]]; then
 		echo
 		echo "Source URL: \"$SOURCE_URL\" is not reachable."


### PR DESCRIPTION
This should have been fixed with RC007 but the `-L` flag was only applied to one.

We might have thought that there may be no need to detect a redirect from GitHub, however, it looks like even a _brand new_ repo thats never had a modified URL can return a 301. I just created a repo and I see GitHub appears to be returning a 301, then going back to the exact same URL, but with HTTP2 enabled.

```
> Host: www.github.com
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 301 
< content-length: 0
< location: https://github.com/KyleTryon/calculator-orb
< 
{ [0 bytes data]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host www.github.com left intact
* Issue another request to this URL: 'https://github.com/KyleTryon/calculator-orb'
*   Trying 140.82.114.4:443...
* Connected to github.com (140.82.114.4) port 443 (#1)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (OUT), TLS handshake, Client hello (1):
} [315 bytes data]
* (304) (IN), TLS handshake, Server hello (2):
{ [122 bytes data]
* (304) (IN), TLS handshake, Unknown (8):
{ [19 bytes data]
* (304) (IN), TLS handshake, Certificate (11):
{ [2459 bytes data]
* (304) (IN), TLS handshake, CERT verify (15):
{ [79 bytes data]
* (304) (IN), TLS handshake, Finished (20):
{ [36 bytes data]
* (304) (OUT), TLS handshake, Finished (20):
} [36 bytes data]
* SSL connection using TLSv1.3 / AEAD-CHACHA20-POLY1305-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=US; ST=California; L=San Francisco; O=GitHub, Inc.; CN=github.com
*  start date: Mar 15 00:00:00 2022 GMT
*  expire date: Mar 15 23:59:59 2023 GMT
*  subjectAltName: host "github.com" matched cert's "github.com"
*  issuer: C=US; O=DigiCert Inc; CN=DigiCert TLS Hybrid ECC SHA384 2020 CA1
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x13300d000)
> GET /KyleTryon/calculator-orb HTTP/2
> Host: github.com
> user-agent: curl/7.79.1
> accept: */*
> 
< HTTP/2 200 
< server: GitHub.com
```