### PR TITLE
Add pre-pack to flatten directory structures

### DIFF
--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -16,11 +16,14 @@ executor: cli/default
 steps:
   - checkout
   - run:
+      name: Pre-pack orb source
+      command: << include(scripts/pre-pack.sh) >>
+  - run:
       name: Packing orb source
       environment:
         ORB_PARAM_SOURCE_DIR: << parameters.source-dir >>
         ORB_PARAM_OUTPUT_DIR: << parameters.output-dir >>
-      command: <<include(scripts/pack.sh)>>
+      command: << include(scripts/pack.sh) >>
   - run:
       name: Validating orb
       environment:
@@ -29,4 +32,4 @@ steps:
   - persist_to_workspace:
       paths:
         - orb.yml
-      root: <<parameters.output-dir>>
+      root: << parameters.output-dir >>

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -28,7 +28,7 @@ steps:
       name: Validating orb
       environment:
         ORB_PARAM_OUTPUT_DIR: << parameters.output-dir >>
-      command: <<include(scripts/validate.sh)>>
+      command: << include(scripts/validate.sh) >>
   - persist_to_workspace:
       paths:
         - orb.yml

--- a/src/scripts/pre-pack.sh
+++ b/src/scripts/pre-pack.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+# Reduce nested commands and jobs to files under src/commands or src/jobs so they can be packed by 'circleci orb pack src/'.
+# Allows you to group collections of commands under directories.
+
+# Directory under which prepack directories reside.
+SRC="${1:-src}"
+
+# The subdirectory to prepack.
+TYP="${2:-commands}"
+
+pre-pack()
+{
+    local current_directory="$1"
+    local d
+
+    cd "$current_directory" || exit 1
+    pwd
+
+    find . -maxdepth 1 -mindepth 1 -type d -print0 | xargs --null -I % basename % | while read -r d; do
+        if [ -n "$(ls "${d}")" ]; then
+            # Drop one level below before processing all of the files and pack those sub-subdirectories into the current subdirectory.
+            pre-pack "$d"
+            find "$d" -maxdepth 1 -mindepth 1 -type f -print0 | xargs --null -I % basename % | while read -r f; do
+                fname="$(basename "$f")"
+                if [ ! -f "${d}-${fname}" ]; then
+                    cp "${d}/${f}" "${d}-${fname}"
+                fi
+            done
+        else
+            printf "INFO: Ignoring '%s', module is empty.\\n" "${SRC}/${TYP}/${d}"
+        fi
+    done
+
+    cd ..
+
+    return 0
+}
+
+pre-pack "$SRC/$TYP/"

--- a/src/scripts/pre-pack.sh
+++ b/src/scripts/pre-pack.sh
@@ -2,12 +2,6 @@
 # Reduce nested commands and jobs to files under src/commands or src/jobs so they can be packed by 'circleci orb pack src/'.
 # Allows you to group collections of commands under directories.
 
-# Directory under which prepack directories reside.
-SRC="${1:-src}"
-
-# The subdirectory to prepack.
-TYP="${2:-commands}"
-
 pre-pack()
 {
     local current_directory="$1"
@@ -36,4 +30,4 @@ pre-pack()
     return 0
 }
 
-pre-pack "$SRC/$TYP/"
+find src -maxdepth 1 -mindepth 1 -type d -print0 | xargs --null -I % basename % | xargs --null -I % pre-pack src/%

--- a/src/scripts/rev-pack.sh
+++ b/src/scripts/rev-pack.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+# Reverse operation of pre-pack.sh. If files exist with a prefix that matches a directory name, they'll be moved under 
+# that directory, and the prefix removed.
+
+# shellcheck disable=SC2216
+
+# Directory under which revpack directories reside.
+SRC="${1:-src}"
+
+# The subdirectory to revpack.
+TYP="${2:-commands}"
+
+# Force deletion of files even if checksums (i.e. their contents) don't match.
+FORCE="${3:-false}"
+
+rev-pack()
+{
+    local current_directory="$1"
+    local f
+
+    cd "$current_directory" || exit 1
+
+    find . -maxdepth 1 -mindepth 1 -type f -print0 | xargs --null -I % basename % | while read -r f; do
+        subdir="$(echo "$f" | awk -F '-' '{ print $1 }')"
+        if [ -d "$subdir" ] && [ -n "$(ls "$subdir")" ]; then
+            fname="${f##"$subdir"-}"
+            # Only remove the file if it has an exact matching counterpart in the subdirectory.
+            if [ -f "${subdir}/${fname}" ]; then
+                if [ "$FORCE" != true ] && [ "$(md5sum "$f" | awk '{ print $1 }')" = "$(md5sum "${subdir}/${fname}" | awk '{ print $1 }')" ]; then
+                    printf "Checksums match, removing '%s'.\\n" "$f"
+                    yes | rm "$f"
+                elif [ "$FORCE" = true ]; then
+                    printf "Skipping checksum and removing '%s'.\\n" "$f"
+                    yes | rm "$f"
+                else
+                    printf "'%s' exists in '%s', but checksums don't match. Skipping removal.\\n" "$fname" "$subdir"
+                fi
+            else
+                printf "'%s' does not exist in '%s'.\\n" "$fname" "$subdir"
+            fi
+        elif [ -d "$subdir" ] && [ -z "$(ls "$subdir")" ]; then
+            printf "Skipping '%s' as the subdirectory '%s' is empty.\\n" "$f" "${subdir}/"
+        else
+            :
+        fi
+    done
+
+    find . -maxdepth 1 -mindepth 1 -type d -print0 | xargs --null -I % basename % | while read -r d; do
+        rev-pack "$d"
+    done
+
+    cd ..
+
+    return 0
+}
+
+rev-pack "$SRC/$TYP/"

--- a/src/scripts/rev-pack.sh
+++ b/src/scripts/rev-pack.sh
@@ -4,14 +4,8 @@
 
 # shellcheck disable=SC2216
 
-# Directory under which revpack directories reside.
-SRC="${1:-src}"
-
-# The subdirectory to revpack.
-TYP="${2:-commands}"
-
 # Force deletion of files even if checksums (i.e. their contents) don't match.
-FORCE="${3:-false}"
+FORCE="${1:-false}"
 
 rev-pack()
 {
@@ -54,4 +48,4 @@ rev-pack()
     return 0
 }
 
-rev-pack "$SRC/$TYP/"
+find src -maxdepth 1 -mindepth 1 -type d -print0 | xargs --null -I % basename % | xargs --null -I % rev-pack src/%


### PR DESCRIPTION
## What

Allows you to group commands and jobs (or even deeper) in their own subdirectories together.

## How

Adds a pre-pack step that condenses the directory structure into a list of files. So a directory structure like
```shell
$ tree -a src/
src/
├── commands
│   ├── context
│   │   ├── add-env-vars.yml
│   │   ├── create.yml
│   │   ├── delete-env-vars.yml
│   │   ├── delete.yml
│   │   ├── get.yml
│   │   ├── list-env-vars.yml
│   │   └── list.yml
│   ├── insights
│   │   └── summary-metrics.yml
...
```
can be reduced to
```shell
$ tree -a src/
src/
├── commands
│   ├── context
│   │   ├── add-env-vars.yml
│   │   ├── create.yml
│   │   ├── delete-env-vars.yml
│   │   ├── delete.yml
│   │   ├── get.yml
│   │   ├── list-env-vars.yml
│   │   └── list.yml
│   ├── context-add-env-vars.yml
│   ├── context-create.yml
│   ├── context-delete-env-vars.yml
│   ├── context-delete.yml
│   ├── context-get.yml
│   ├── context-list-env-vars.yml
│   ├── context-list.yml
│   ├── insights
│   │   └── summary-metrics.yml
│   ├── insights-summary-metrics.yml
...
```
Note that the files are now prefixed by their former containing directory's name.

I've also included a script to accomplish the reverse for any local shell users. I typically add the following to my `package.json` -
```json
{
...
"scripts": {
    "install:pre-commit:mac": "brew install pre-commit",
    "install:pre-commit:pip": "pip install pre-commit",
    "install:pre-commit-hooks": "pre-commit install --install-hooks --allow-missing-config -t pre-commit -t prepare-commit-msg",
    "orb:pack": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/pre-pack.sh src % && circleci orb pack src/ > orb.yml",
    "orb:validate": "circleci orb validate orb.yml",
    "orb:cleanup": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/rev-pack.sh src %; yes | rm orb.yml",
    "orb:clean": "yarn orb:cleanup",
    "orb:cleanup:force": "find src -maxdepth 1 -mindepth 1 -type d | xargs -I % basename % | xargs -I % ./scripts/rev-pack.sh src % true; yes | rm orb.yml",
    "orb:clean:force": "yarn orb:cleanup:force"
  }
...
}
```
so I can call these steps more easily, and against every subdirectory under `src/`.

## Why

As far as use-cases, I've found myself wrapping CLIs and APIs as of late, and the base directories under `src/commands` and `src/jobs` get crowded for complex interfaces. Plus, it's easier to navigate if you're able to group related commands (which I'd typically prefix with the directory name, anyway, so they're grouped together in my editor's directory list).