### PR TITLE
feat(jobs): add `resource_class` overrides

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,0 +1,19 @@
+description: >
+  The circleci-cli Docker image, which includes the CircleCI CLI
+
+parameters:
+  tag:
+    type: string
+    default: latest
+    description: >
+      What version of the CircleCI CLI Docker image? For full list, see
+      https://hub.docker.com/r/circleci/circleci-cli/tags
+  resource_class:
+    description: Configure the xecutor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
+
+resource_class: << parameters.resource_class >>
+docker:
+  - image: circleci/circleci-cli:<< parameters.tag >>

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -3,6 +3,7 @@ description: |
 
 docker:
   - image: cimg/base:current
+resource_class: << parameters.resource_class >>
 
 parameters:
   pipeline-number:
@@ -28,6 +29,11 @@ parameters:
     description: Host URL of CircleCI Web UI. If you are using self-hosted CircleCI, this value should be set.
     type: string
     default: https://app.circleci.com
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
 
 steps:
   - checkout

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -2,7 +2,15 @@ description: |
   Lint all YAML files in the project. A ".yamllint" file will be generated for you automatically by the Orb Development Kit.
 
 docker:
-  - image: cimg/python:3.10.2
+  - image: cimg/python:3.10.5
+resource_class: << parameters.resource_class >>
+
+parameters:
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
 
 steps:
   - checkout

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -2,6 +2,11 @@ description: |
   Packs the orb source into a single "orb.yml" file and validates for orb config errors.
 
 parameters:
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
   source-dir:
     description: Path to the orb source. Path must be absolute or relative to the working directory.
     type: string
@@ -11,7 +16,9 @@ parameters:
     type: string
     default: ./dist/
 
-executor: cli/default
+executor:
+  name: default
+  resource_class: << parameters.resource_class >>
 
 steps:
   - checkout

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -2,9 +2,16 @@ description: |
   Publish a new version of your orb.
   This job will produce a development version of an orb by default or will produce a new production version if the $CIRCLE_TAG environment variable is , and the "pub-type" parameter is set to "production".
 
-executor: cli/default
+executor:
+  name: default
+  resource_class: << parameters.resource_class >>
 
 parameters:
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
   orb-name:
     type: string
     description: >
@@ -50,6 +57,7 @@ parameters:
       - dev
       - production
     default: "dev"
+
 steps:
   - attach_workspace:
       at: <<parameters.orb-dir>>

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -10,9 +10,15 @@ parameters:
       Example: "RC001,RC002"
     type: string
     default: ""
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
 
 docker:
   - image: cimg/base:current
+resource_class: << parameters.resource_class >>
 
 steps:
   - checkout


### PR DESCRIPTION
- Add the ability to set resource classes for jobs, setting the default `resource_class` to `medium`.
- Add a new `default` executor here; replacing the one we called from CircleCI-Public/circleci-cli-orb
- Update cimg python executor to `cimg/python:3.10.5`

See also
CircleCI-Public/circleci-cli-orb#17