### PR TITLE
Add pre-commit hooks and set resource_class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.6
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/bjd2385/circleci-config-pre-commit-hook
+    rev: v1.0.3
+    hooks:
+      - id: circleci-config-validate
+
+  - repo: https://github.com/bjd2385/circleci-orb-pre-commit-hook
+    rev: v1.1.0
+    hooks:
+      - id: circleci-orb-validate
+        args: [src/]

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -3,6 +3,7 @@ description: |
 
 docker:
   - image: cimg/base:current
+resource_class: small
 
 parameters:
   pipeline-number:

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -3,6 +3,7 @@ description: |
 
 docker:
   - image: cimg/python:3.10.2
+resource_class: small
 
 steps:
   - checkout

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -12,6 +12,7 @@ parameters:
     default: ./dist/
 
 executor: cli/default
+resource_class: small
 
 steps:
   - checkout

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -3,6 +3,7 @@ description: |
   This job will produce a development version of an orb by default or will produce a new production version if the $CIRCLE_TAG environment variable is , and the "pub-type" parameter is set to "production".
 
 executor: cli/default
+resource_class: small
 
 parameters:
   orb-name:

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -13,6 +13,7 @@ parameters:
 
 docker:
   - image: cimg/base:current
+resource_class: small
 
 steps:
   - checkout


### PR DESCRIPTION
Adds pre-commit hooks and sets default `resource_class` to `small`, since `large` is a bit overkill?