### PR TITLE
Feat(#162): Adding a version parameter.

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -59,13 +59,18 @@ parameters:
   pub-type:
     description: |
       Select the publishing type. Available options are "dev" and "production".
-      If "production" is selected, the orb will be published to the orb registry only if the $CIRCLE_TAG environment variable is set. Publishing will be skipped otherwise.
+      If "production" is selected, the orb will be published to the orb registry with the content of orb-version parameter, defaulting to the $CIRCLE_TAG environment variable. Publishing will be skipped if no value can be found.
       If "dev" is selected, two tags will be created: "dev:alpha" and "dev:<SHA1>".
     type: enum
     enum:
       - dev
       - production
     default: "dev"
+  orb-version:
+    description: |
+      Declare the orb version for publishing. Defaults to $CIRCLE_TAG content.
+    type: string
+    default: <<pipeline.git.tag>>
 
 steps:
   - attach_workspace:
@@ -79,6 +84,7 @@ steps:
         ORB_PARAM_PUB_TYPE: <<parameters.pub-type>>
         PARAM_GH_TOKEN: <<parameters.github-token>>
         CIRCLECI_API_HOST: <<parameters.circleci-api-host>>
+        ORB_VERSION: <<parameters.orb-version>>
       command: <<include(scripts/publish.sh)>>
   - when:
       condition: <<parameters.enable-pr-comment>>

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 function validateProdTag() {
-  if [[ ! "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ ! "${ORB_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Malformed tag detected."
-    echo "Tag: $CIRCLE_TAG"
+    echo "Tag: $ORB_VERSION"
     echo
     echo "Ensure your tag fits the standard semantic version form. Example: v1.0.0"
     echo "Aborting deployment. Push a new tag with the compatible form."
@@ -47,13 +47,13 @@ function orbPublish() {
 
   if [ "$ORB_PARAM_PUB_TYPE" == "production" ]; then
     echo "Production release detected!"
-    if [ -z "$CIRCLE_TAG" ]; then
+    if [ -z "$ORB_VERSION" ]; then
       echo "No tag detected. Peacfully exiting."
       echo "If you are trying to publish a production orb, you must push a semantically versioned tag."
       exit 0
     fi
     validateProdTag
-    ORB_RELEASE_VERSION="${CIRCLE_TAG//v/}"
+    ORB_RELEASE_VERSION="${ORB_VERSION//v/}"
     echo "Production version: ${ORB_RELEASE_VERSION}"
     printf "\n"
     publishOrb "${ORB_RELEASE_VERSION}"


### PR DESCRIPTION
This is a draft for the suggestion in discussion in issue #162 . I'm not used to authoring orb, so please lmk if I can improve something.

The idea behind this PR is to decouple the version from GITHUB_TAG, allowing the intended tag to be passed as a parameter. As a result, anyone with a custom TAG definition or who organizes their orbs in a monorepo would be able to publish their orbs without any friction.

Although it would open the possibility for publishing to fail if the parameter diverges from the expected semver format, anyone who's programming their own pipeline to publish should be able to quickly detect and fix their issue by passing the parameter properly as per documentation.

In order to maintain backwards compatibility, GITHUB_TAG could still be used as the default parameter - if none is passed.