### PR TITLE
Prevent invalid warning when var ENV 'ORB_PARAM_ORB_PUB_TOKEN' isn't define

### DIFF
--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -13,7 +13,7 @@ function validateProdTag() {
 function validateOrbPubToken() {
   if [[ -z "${ORB_PARAM_ORB_PUB_TOKEN}" ]]; then
     echo "No Orb Publishing Token detected."
-    echo "Please set the ORB_PARAM_ORB_PUB_TOKEN environment variable."
+    echo "Please set the CIRCLE_TOKEN environment variable."
     echo "Aborting deployment."
     exit 1
   fi


### PR DESCRIPTION
I know the resolution of this issue can appears weird. But it just happen to me and I had to look at the source code to understand. 
Also I think the doc should mention that it is required.

This is ORB_PARAM_ORB_PUB_TOKEN but it is defined via a parameter with a default as CIRCLE_TOKEN.

If you set ORB_PARAM_ORB_PUB_TOKEN in a context it will not work with the orb template but if you set CIRCLE_TOKEN it is working properly.