### PR TITLE
We should be able to publish without packing

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -68,6 +68,7 @@ parameters:
     default: "dev"
 
 steps:
+  - checkout
   - attach_workspace:
       at: <<parameters.orb-dir>>
   - run:


### PR DESCRIPTION
When using only lint + publish and a custom "orb-dir" like :
  orb-dir: ./src

File can never be found. Like other jobs we should let the user interact with the code and checkout it.
At the moment having the command with "orb-dir: ./src" produces:
```
  Error: Could not load config file at ./src/orb.yml: open ./src/orb.yml: no such file or directory
```