### PR TITLE
feat: parameterize the command's maximum allowed length (RC009)

### DIFF
--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -19,6 +19,13 @@ parameters:
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
+  max_command_length:
+    description: |
+      The maximum length of a command (RC009).
+      This is used to check for commands that are too long.
+      Commands longer than this will fail the review.
+    type: integer
+    default: 64
 
 docker:
   - image: cimg/base:current
@@ -31,6 +38,7 @@ steps:
       name: Review Best Practices
       environment:
         PARAM_RC_EXCLUDE: <<parameters.exclude>>
+        PARAM_MAX_COMMAND_LENGTH: <<parameters.exclude>>
         ORB_REVIEW_BATS_FILE: <<include(scripts/review.bats)>>
         ORB_PARAM_SOURCE_DIR: << parameters.source-dir >>
       command: <<include(scripts/review.sh)>>

--- a/src/scripts/review.bats
+++ b/src/scripts/review.bats
@@ -164,7 +164,7 @@ setup() {
 				echo "$ORB_COMPONENT_STEP"
 				echo ---
 				ERROR_COUNT=$((ERROR_COUNT + 1))
-			elif [[ "${#ORB_COMPONENT_STEP_COMMAND}" -gt 64 ]]; then
+			elif [[ "${#ORB_COMPONENT_STEP_COMMAND}" -gt "${PARAM_MAX_COMMAND_LENGTH}" ]]; then
 				if [[ ! "$ORB_COMPONENT_STEP_COMMAND" =~ \<\<include\(* ]]; then
 					echo "File: \"${i}\""
 					echo "Line number: ${ORB_COMPONENT_LINE_NUMBER}"


### PR DESCRIPTION
## Motivation

Closes #151 

## Changes

This PR adds a new parameter to allow the customization of the maximum allowed character length in commands.