### PR TITLE
fix: parameter sent to `review.bats`

### DIFF
--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -38,7 +38,7 @@ steps:
       name: Review Best Practices
       environment:
         PARAM_RC_EXCLUDE: <<parameters.exclude>>
-        PARAM_MAX_COMMAND_LENGTH: <<parameters.exclude>>
+        PARAM_MAX_COMMAND_LENGTH: <<parameters.max_command_length>>
         ORB_REVIEW_BATS_FILE: <<include(scripts/review.bats)>>
         ORB_PARAM_SOURCE_DIR: << parameters.source-dir >>
       command: <<include(scripts/review.sh)>>

--- a/src/scripts/review.bats
+++ b/src/scripts/review.bats
@@ -168,7 +168,7 @@ setup() {
 				if [[ ! "$ORB_COMPONENT_STEP_COMMAND" =~ \<\<include\(* ]]; then
 					echo "File: \"${i}\""
 					echo "Line number: ${ORB_COMPONENT_LINE_NUMBER}"
-					echo "This command appears longer than 64 characters. Consider using the 'include' syntax."
+					echo "This command appears longer than ${PARAM_MAX_COMMAND_LENGTH} characters. Consider using the 'include' syntax."
 					echo ---
 					echo "$ORB_COMPONENT_STEP_COMMAND"
 					echo ---


### PR DESCRIPTION
## Motivation

The parameter included in #169 didn't use the YAML's correct argument. Additionally, the error message had a hard-coded character count.

## Changes

Fix the YAML's parameter and the error message.