### PR TITLE
feat: allow consumer to set tag for CircleCI images

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -9,7 +9,7 @@ parameters:
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags
   resource_class:
-    description: Configure the xecutor resource class
+    description: Configure the executor resource class
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -39,7 +39,7 @@ parameters:
     default: "current"
     description: |
       By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
-      https://circleci.com/developer/images/image/cimg/base    
+      https://circleci.com/developer/images/image/cimg/base
 
 steps:
   - checkout

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -2,7 +2,7 @@ description: |
   After the "publish-dev" job has completed along with any other preliminary checks, this job will trigger the next workflow (test-deploy) in the Orb Development Kit.
 
 docker:
-  - image: cimg/base:<< parameters.image-tag >>
+  - image: cimg/base:<< parameters.tag >>
 resource_class: << parameters.resource_class >>
 
 parameters:
@@ -34,7 +34,7 @@ parameters:
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
-  image-tag:
+  tag:
     type: string
     default: "current"
     description: |

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -2,7 +2,7 @@ description: |
   After the "publish-dev" job has completed along with any other preliminary checks, this job will trigger the next workflow (test-deploy) in the Orb Development Kit.
 
 docker:
-  - image: cimg/base:current
+  - image: cimg/base:<< parameters.image-tag >>
 resource_class: << parameters.resource_class >>
 
 parameters:
@@ -34,6 +34,12 @@ parameters:
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
+  image-tag:
+    type: string
+    default: "current"
+    description: |
+      By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
+      https://circleci.com/developer/images/image/cimg/base    
 
 steps:
   - checkout

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -20,10 +20,17 @@ parameters:
     description: Host URL of CircleCI API. If you are using self-hosted CircleCI, this value should be set.
     type: string
     default: https://circleci.com
+  image-tag:
+    type: string
+    default: "current"
+    description: >
+      What version of the CircleCI CLI Docker image? For full list, see
+      https://hub.docker.com/r/circleci/circleci-cli/tags
 
 executor:
   name: default
   resource_class: << parameters.resource_class >>
+  tag: << parameters.image-tag >>
 
 steps:
   - checkout

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -20,7 +20,7 @@ parameters:
     description: Host URL of CircleCI API. If you are using self-hosted CircleCI, this value should be set.
     type: string
     default: https://circleci.com
-  image-tag:
+  tag:
     type: string
     default: "current"
     description: >
@@ -30,7 +30,7 @@ parameters:
 executor:
   name: default
   resource_class: << parameters.resource_class >>
-  tag: << parameters.image-tag >>
+  tag: << parameters.tag >>
 
 steps:
   - checkout

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -22,7 +22,7 @@ parameters:
     default: https://circleci.com
   tag:
     type: string
-    default: "current"
+    default: "latest"
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -5,6 +5,7 @@ description: |
 executor:
   name: default
   resource_class: << parameters.resource_class >>
+  tag: << parameters.image-tag >>
 
 parameters:
   resource_class:
@@ -66,6 +67,12 @@ parameters:
       - dev
       - production
     default: "dev"
+  image-tag:
+    type: string
+    default: "current"
+    description: >
+      What version of the CircleCI CLI Docker image? For full list, see
+      https://hub.docker.com/r/circleci/circleci-cli/tags
 
 steps:
   - attach_workspace:

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -5,7 +5,7 @@ description: |
 executor:
   name: default
   resource_class: << parameters.resource_class >>
-  tag: << parameters.image-tag >>
+  tag: << parameters.tag >>
 
 parameters:
   resource_class:
@@ -67,7 +67,7 @@ parameters:
       - dev
       - production
     default: "dev"
-  image-tag:
+  tag:
     type: string
     default: "current"
     description: >

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -69,7 +69,7 @@ parameters:
     default: "dev"
   tag:
     type: string
-    default: "current"
+    default: "latest"
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -31,7 +31,7 @@ parameters:
     default: "current"
     description: |
       By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
-      https://circleci.com/developer/images/image/cimg/base   
+      https://circleci.com/developer/images/image/cimg/base
 
 docker:
   - image: cimg/base:<< parameters.tag >>

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -26,9 +26,15 @@ parameters:
       Commands longer than this will fail the review.
     type: integer
     default: 64
+  image-tag:
+    type: string
+    default: "current"
+    description: |
+      By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
+      https://circleci.com/developer/images/image/cimg/base    
 
 docker:
-  - image: cimg/base:current
+  - image: cimg/base:<< parameters.image-tag >>
 resource_class: << parameters.resource_class >>
 
 steps:

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -31,7 +31,7 @@ parameters:
     default: "current"
     description: |
       By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
-      https://circleci.com/developer/images/image/cimg/base    
+      https://circleci.com/developer/images/image/cimg/base   
 
 docker:
   - image: cimg/base:<< parameters.image-tag >>

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -26,7 +26,7 @@ parameters:
       Commands longer than this will fail the review.
     type: integer
     default: 64
-  image-tag:
+  tag:
     type: string
     default: "current"
     description: |
@@ -34,7 +34,7 @@ parameters:
       https://circleci.com/developer/images/image/cimg/base   
 
 docker:
-  - image: cimg/base:<< parameters.image-tag >>
+  - image: cimg/base:<< parameters.tag >>
 resource_class: << parameters.resource_class >>
 
 steps:


### PR DESCRIPTION
This feature is modeled after https://github.com/CircleCI-Public/shellcheck-orb/blob/master/src/jobs/check.yml#L7 .

I'm attempting to author an Orb within my company's CircleCI Server v3 instance.  We have imported the orbs published under the `circleci/*` namespace. When using the jobs defined in this Orb, I'm getting the following error message at the `checkout` step:

```
Using SSH Config Dir '/home/circleci/.ssh'
git version 2.38.0
Cloning git repository
Cloning into '.'...
error: cannot create async thread: Operation not permitted
fatal: fetch-pack: unable to fork off sideband demultiplexer

exit status 128
CircleCI received exit code 128
```

I'd like this feature as a work-around to the potential underlying issue described [here](https://bugs.launchpad.net/ubuntu/+bug/1992485). The workaround is to use an Alpine or Ubuntu 21.04 based image. 
