### PR TITLE
fix: set known good image tag to fix yq

### DIFF
--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -28,7 +28,7 @@ parameters:
     default: 64
   tag:
     type: string
-    default: "current"
+    default: "2022.12-18.04"
     description: |
       By default the most current stable release of `cimg/base` image will be used, but you may statically set the image tag with this parameter.
       https://circleci.com/developer/images/image/cimg/base


### PR DESCRIPTION
It has been discovered that the RC008 review job does not work with versions of YQ v4.29.1 or higher. Pinning the review job tag to the last known good tag for cimg/base which contains YQ version `4.27.5`.