### PR TITLE
feat: allow custom tags

### DIFF
--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 function validateProdTag() {
-  if [[ ! "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  if [[ ! "${CIRCLE_TAG}" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     echo "Malformed tag detected."
     echo "Tag: $CIRCLE_TAG"
     echo
@@ -53,7 +53,7 @@ function orbPublish() {
       exit 0
     fi
     validateProdTag
-    ORB_RELEASE_VERSION="${CIRCLE_TAG//v/}"
+    ORB_RELEASE_VERSION="$(printf '%s' "CIRCLE_TAG" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')"
     echo "Production version: ${ORB_RELEASE_VERSION}"
     printf "\n"
     publishOrb "${ORB_RELEASE_VERSION}"

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -53,7 +53,7 @@ function orbPublish() {
       exit 0
     fi
     validateProdTag
-    ORB_RELEASE_VERSION="$(printf '%s' "CIRCLE_TAG" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')"
+    ORB_RELEASE_VERSION="$(printf '%s' "$CIRCLE_TAG" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')"
     echo "Production version: ${ORB_RELEASE_VERSION}"
     printf "\n"
     publishOrb "${ORB_RELEASE_VERSION}"


### PR DESCRIPTION
## Motivation

Closes #162 

## Changes

- Instead of assuming the entire tag will be a semver, this change looks for a semver match at any point in the tag:

Prior to this change:
```
❌ circle-orb-v1.2.3
❌ circle-v1.2.3-orb
❌ v1.2.3-circle-orb
✅ v1.2.3
```

After this change:
```
✅ circle-orb-v1.2.3
✅ circle-v1.2.3-orb
✅ v1.2.3-circle-orb
✅ v1.2.3
```


- The orb release version is now grep-ed from the tag string as long as there is a match in the format `x.x.x` where `x` is a number.