### PR TITLE
fix: Make orb release version regex greedy for patch versions

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -26,7 +26,7 @@ parameters:
       A Regular Expression to compare against `$CIRCLE_TAG` when publishing a production version of an orb.
       Your tag must include a full semantic version number, which will be used to automatically version the published orb.
       Ensure you CircleCI config is also properly configured to trigger for this tag pattern.
-      It is recommended to prefix or suffix around this pattern: '[0-9]+\.[0-9]+\.[0-9]'.
+      It is recommended to prefix or suffix around this pattern: '[0-9]+\.[0-9]+\.[0-9]+'.
     default: '^v[0-9]+\.[0-9]+\.[0-9]+$'
     type: string
   circleci-token:

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -54,7 +54,7 @@ function orbPublish() {
       exit 0
     fi
     validateProdTag
-    ORB_RELEASE_VERSION="$(echo "${CIRCLE_TAG}" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]")"
+    ORB_RELEASE_VERSION="$(echo "${CIRCLE_TAG}" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")"
     echo "Production version: ${ORB_RELEASE_VERSION}"
     printf "\n"
     publishOrb "${ORB_RELEASE_VERSION}"


### PR DESCRIPTION
Fix for #182 - Make orb release version greedy for patch versions