### PR TITLE
chore: Improve wording relating to review checks

### DIFF
--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -1,12 +1,12 @@
 description: |
-  Automatically reviews your orb for best practices and produces JUNIT test reports which are natively displayed in the CircleCI UI.
+  Automatically reviews your orb for best practices and produces JUnit test reports which are natively displayed in the CircleCI UI.
   The "Review" job checks against a suite of "RC" review checks, and if an opportunity for improvement is found, a suggestion with links to the relevant documentation is made.
 
 parameters:
   exclude:
     description: |
-      A comma separated list of "RC"" codes to explicitly ignore.
-      Each review test has an associated RC code that can be included to skip in future tests. If a review item fails, the RC code will be included in the output.
+      A comma separated list of "RC" review check codes to explicitly ignore.
+      Each review check has an associated "RC" code that can be identified to skip in future tests. If a review check fails, the "RC" code will be included in the output.
       Example: "RC001,RC002"
     type: string
     default: ""


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

This PR fixes a trivial typo of a double quote in a description, but attempts to also slightly improve the wording when it refers to review checks.  (early on, I kept forgetting what "RC" stood for)

<img width="396" alt="image" src="https://user-images.githubusercontent.com/33203301/211963725-eb556071-e7e1-4948-8a61-68b9b8c6c885.png">
