### PR TITLE
Feature: Introduce orb filename parameter

### DIFF
--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -1,5 +1,5 @@
 description: |
-  Packs the orb source into a single "orb.yml" file and validates for orb config errors.
+  Packs the orb source into a single "orb.yml" otherwise into "output-filename" if specified  file and validates for orb config errors.
   For self-hosted CircleCI servers, please ensure you set the `circleci-api-host` job parameter and CIRCLE_TOKEN environment variable.
 
 parameters:
@@ -13,9 +13,13 @@ parameters:
     type: string
     default: ./src/
   output-dir:
-    description: The orb output directory. The orb will be named "orb.yml" in this directory and persisted to the workspace. Path must be absolute or relative to the working directory.
+    description: The orb output directory. The orb will be named "orb.yml" or as specified with the "output-filename" parameter in this directory and persisted to the workspace. Path must be absolute or relative to the working directory.
     type: string
     default: ./dist/
+  output-filename:
+    description: The orb output filename.
+    type: string
+    default: orb.yml
   circleci-api-host:
     description: Host URL of CircleCI API. If you are using self-hosted CircleCI, this value should be set.
     type: string
@@ -39,14 +43,16 @@ steps:
       environment:
         ORB_PARAM_SOURCE_DIR: << parameters.source-dir >>
         ORB_PARAM_OUTPUT_DIR: << parameters.output-dir >>
+        ORB_PARAM_OUTPUT_FILENAME: <<parameters.output-filename>>
       command: <<include(scripts/pack.sh)>>
   - run:
       name: Validating orb
       environment:
         ORB_PARAM_OUTPUT_DIR: << parameters.output-dir >>
+        ORB_PARAM_OUTPUT_FILENAME: <<parameters.output-filename>>
         CIRCLECI_API_HOST: <<parameters.circleci-api-host>>
       command: <<include(scripts/validate.sh)>>
   - persist_to_workspace:
       paths:
-        - orb.yml
+        - <<parameters.output-filename>>
       root: <<parameters.output-dir>>

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -21,6 +21,10 @@ parameters:
     description: Directory containing packed orb source. Path must be absolute or relative to the working directory. Should match the "output-dir" of the "pack" job.
     type: string
     default: ./dist/
+  orb-filename:
+    description: Filename of the packed orb source file. orb-filename parameter is joined together with the orb-dir parameter to produce full path.
+    type: string
+    default: orb.yml
   tag-pattern:
     description: |
       A Regular Expression to compare against `$CIRCLE_TAG` when publishing a production version of an orb.
@@ -91,6 +95,7 @@ steps:
         ORB_PARAM_ORB_PUB_TOKEN: <<parameters.circleci-token>>
         ORB_PARAM_ORB_NAME: <<parameters.orb-name>>
         ORB_PARAM_ORB_DIR: <<parameters.orb-dir>>
+        ORB_PARAM_ORB_FILENAME: <<parameters.orb-filename>>
         ORB_PARAM_PUB_TYPE: <<parameters.pub-type>>
         ORB_PARAM_TAG_PATTERN: <<parameters.tag-pattern>>
         PARAM_GH_TOKEN: <<parameters.github-token>>

--- a/src/scripts/pack.sh
+++ b/src/scripts/pack.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-mkdir -p "$ORB_PARAM_OUTPUT_DIR" && circleci orb pack --skip-update-check "$ORB_PARAM_SOURCE_DIR" >"${ORB_PARAM_OUTPUT_DIR}orb.yml"
+mkdir -p "$ORB_PARAM_OUTPUT_DIR" && circleci orb pack --skip-update-check "$ORB_PARAM_SOURCE_DIR" >"${ORB_PARAM_OUTPUT_DIR}/${ORB_PARAM_OUTPUT_FILENAME}"

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -22,7 +22,7 @@ function validateOrbPubToken() {
 
 function publishOrb() {
   #$1 = full tag
-  circleci orb publish --host "${CIRCLECI_API_HOST:-https://circleci.com}" --skip-update-check "${ORB_PARAM_ORB_DIR}/orb.yml" "${ORB_PARAM_ORB_NAME}@${1}" --token "$ORB_PARAM_ORB_PUB_TOKEN"
+  circleci orb publish --host "${CIRCLECI_API_HOST:-https://circleci.com}" --skip-update-check "${ORB_PARAM_ORB_DIR}/${ORB_PARAM_ORB_FILENAME}" "${ORB_PARAM_ORB_NAME}@${1}" --token "$ORB_PARAM_ORB_PUB_TOKEN"
   printf "\n"
   {
     echo "Your orb has been published to the CircleCI Orb Registry."

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -6,4 +6,4 @@ if [ "https://circleci.com" != "${CIRCLECI_API_HOST}" ] && [ -z "${CIRCLE_TOKEN}
     exit 1
 fi
 
-circleci orb validate --host "${CIRCLECI_API_HOST:-https://circleci.com}" --token "${CIRCLE_TOKEN:-dummy}" --skip-update-check "${ORB_PARAM_OUTPUT_DIR}orb.yml"
+circleci orb validate --host "${CIRCLECI_API_HOST:-https://circleci.com}" --token "${CIRCLE_TOKEN:-dummy}" --skip-update-check "${ORB_PARAM_OUTPUT_DIR}/${ORB_PARAM_OUTPUT_FILENAME}"


### PR DESCRIPTION
Introduce new parameters on pack and publish jobs to allow setting custom pack output filename.

To avoid breaking changes these parameters default to previously hardcoded value on scripts - `orb.yml`

Motivation for this change is that running multiple pack/publish jobs for different orbs within a singlw workflow does not work. When multiple orbs are packed and published, run on circleci fails as multiple files with the same name are attached on the workspace resulting in conflicts in the form of: 
```
Concurrent upstream jobs persisted the same file(s) into the workspace:
  - orb.yml
```

In other words, this proposal can be seen as a bugfix.

In our use case we have set up a monorepo containing source for multiple orbs. On pull-request merges to master all orbs are published as dev versions. Releases - publish version - are done for each orb individually - using version tags prefixed with the orb name.