### PR TITLE
fix: add tag filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,21 @@ orbs:
   orb-tools-alpha: circleci/orb-tools@dev:alpha
   shellcheck: circleci/shellcheck@3.1
 
+filters: &filters
+  tags:
+    only: /.*/
+
 workflows:
   lint-pack:
     jobs:
-      - orb-tools-alpha/lint
-      - orb-tools-alpha/pack
-      - orb-tools-alpha/review
-      - shellcheck/check
+      - orb-tools-alpha/lint:
+          filters: *filters
+      - orb-tools-alpha/pack:
+          filters: *filters
+      - orb-tools-alpha/review:
+          filters: *filters
+      - shellcheck/check:
+          filters: *filters
       - orb-tools-alpha/continue:
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
@@ -25,3 +33,4 @@ workflows:
               orb-tools-alpha/pack,
               shellcheck/check,
             ]
+          filters: *filters


### PR DESCRIPTION
We originally thought these filters may not be needed, however, when we attempted to publish, the workflow did not trigger. Adding back these filters.