### PR TITLE
chore: update CLI

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   tag:
     type: string
-    default: "0.1.26094"
+    default: "0.1.26646"
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags


### PR DESCRIPTION
Update the cli docker image to include newest updates for private orb support