### PR TITLE
use the latest version of circleci/circleci-cli orb

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,5 +10,5 @@ display:
   home_url: https://circleci.com/docs/2.0/orb-author/
 
 orbs:
-  cli: circleci/circleci-cli@0.1
+  cli: circleci/circleci-cli@0.1.9
   bats: circleci/bats@1.0.0


### PR DESCRIPTION
circleci/circleci-cli orb has fixes to issues in its latest version, such as support for org's private orb with handling backward compatibility as mentioned in this pr https://github.com/CircleCI-Public/circleci-cli/pull/934