### PR TITLE
[semver:minor] Add circleci ip range options

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -55,8 +55,15 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
 
 executor: << parameters.executor >>
+
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
 steps:
   - when:

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -15,8 +15,15 @@ parameters:
     description: The executor to use for this job. By default, this will use the "python" executor provided by this orb.
     type: executor
     default: python
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
 
 executor: << parameters.executor >>
+
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
 steps:
   - when:

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -45,8 +45,16 @@ parameters:
       You can use "org_id" instead if you prefer.
     type: string
     default: ""
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
+
 
 executor: << parameters.executor >>
+
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
 steps:
   - when:

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -92,8 +92,16 @@ parameters:
       This will attempt to attach the workspace at the path specified by the "orb_dir" parameter.
       It is expected that the workspace will contain 'orb_source.tar.gz' which should contain one or more orb source files.
       The tar file will be extracted to the "orb_dir" path.
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
+
 
 executor: << parameters.executor >>
+
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
 steps:
   - when:

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -30,8 +30,15 @@ parameters:
     description: The executor to use for this job. By default, this will use the "python" executor provided by this orb.
     type: executor
     default: python
+  circleci_ip_ranges:
+    type: boolean
+    default: false
+    description: |
+      The IP ranges feature enables users to restrict network access to CircleCI jobs by allowing only requests originating from specified IP ranges. For detailed documentation on "circleci_ip_ranges", you can refer to the official CircleCI documentation: [IP Ranges](https://circleci.com/docs/ip-ranges/)
 
 executor: << parameters.executor >>
+
+circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
 steps:
   - when:


### PR DESCRIPTION
## Changes

Customer reported that when they have their GitHub managed allowed IP enabled they can not checkout using the orb tools.  To mitigate this issue I added the `circleci_ip_ranges` options.

> [Managing allowed IP addresses for your organization](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization): You can restrict access to your organization's private assets by configuring a list of IP addresses that are allowed to connect.

## Additional note

I thought of creating an executor that enables this but it looks like `circleci_ip_ranges` are not supported. There fore I gave up on creating an executor and created a pr to directly address this issue.

<img width="649" alt="Screenshot 2023-07-18 at 15 08 25" src="https://github.com/CircleCI-Public/orb-tools-orb/assets/6015450/2c20c2b9-40e8-41f9-996d-f234355e7c75">

related changes: https://github.com/CircleCI-Public/shellcheck-orb/pull/59
