### PR TITLE
fix: use load to slurp YAML file

### DIFF
--- a/src/scripts/continue.sh
+++ b/src/scripts/continue.sh
@@ -46,9 +46,10 @@ checkRequirements() {
 # Inject orb source into the configuration
 injectOrb() {
 	printf "Injecting orb source into configuration.\n"
-	ORB_SOURCE="$(cat "${ORB_DIR}/${ORB_FILE}")"
+	ORB_SOURCE="${ORB_DIR}/${ORB_FILE}"
 	export ORB_SOURCE
-	MODIFIED_CONFIG="$(yq '.orbs.[env(ORB_VAL_ORB_NAME)] = env(ORB_SOURCE)' "${ORB_VAL_CONTINUE_CONFIG_PATH}")"
+	# NOTE: load function from yq is only available from v4.x
+	MODIFIED_CONFIG="$(yq '.orbs.[env(ORB_VAL_ORB_NAME)] = load(env(ORB_SOURCE))' "${ORB_VAL_CONTINUE_CONFIG_PATH}")"
 	printf "Modified config:\n\n"
 	printf "%s" "${MODIFIED_CONFIG}"
 	printf "%s" "${MODIFIED_CONFIG}" >"/tmp/circleci/modified/${ORB_FILE}"


### PR DESCRIPTION
This change leverages the [load function](https://mikefarah.gitbook.io/yq/operators/load#replace-node-with-referenced-file) from yq.
It allows us to load the full content from a YAML file. This way, we do not need to cat the YAML file content in a prior step.

In addition, I believe this can avoid the 'Argument list too long' yq error.
Related: https://stackoverflow.com/questions/70278587/yq-v4-env-operator-returning-errnoe2big-argument-list-too-long

I've made [a sample project](https://github.com/kelvintaywl-cci/explore-yq) to showcase the proposed change.
Public workflow here:
https://app.circleci.com/pipelines/github/kelvintaywl-cci/explore-yq/2/workflows/12f05943-7c50-453b-a680-210979221316/jobs/2


### additional

I confirmed that the executors have yq >= 4.x so the load function should indeed be available for the continue job (if executor is kept as default).

```console
# docker image of orb-tools/default executor
$ docker run --rm circleci/circleci-cli:0.1.26646 yq --version
yq (https://github.com/mikefarah/yq/) version v4.31.2

# docker image of orb-tools/python executor
$ docker run --rm cimg/python:3.11 yq --version
yq (https://github.com/mikefarah/yq/) version v4.30.6
```