### PR TITLE
Improve migration docs - example

### DIFF
--- a/src/examples/step2_test-deploy.yml
+++ b/src/examples/step2_test-deploy.yml
@@ -34,13 +34,30 @@ usage:
               tags:
                 only: /.*/
         # Because our publishing job has a tag filter, we must also apply a filter to each job it depends on.
+        - orb-tools/pack:
+            requires:
+              - command-tests
+              - <my-orb>/my_job
+            filters:
+              tags:
+                only: /.*/
+        - orb-tools/publish:
+            name: publish_dev_test
+            orb_name: <namespace>/<my-orb>
+            pub_type: dev
+            vcs_type: <<pipeline.project.type>>
+            requires: [orb-tools/pack]
+            context: [orb-publishing-context]
+            filters:
+              tags:
+                ignore: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+              branches:
+                ignore: /^pull/[0-9]+/
         - orb-tools/publish:
             orb_name: <namespace>/<my-orb>
             pub_type: production
             vcs_type: <<pipeline.project.type>>
-            requires:
-              - command-tests
-              - <my-orb>/my_job
+            requires: [orb-tools/pack]
             context: [orb-publishing-context]
             filters:
               tags:


### PR DESCRIPTION
Split from #220 as CCI can't accept PRs that update the docs, examples and build code all in the same PR.

This PR updates the example build suggested by this orb to best take advantage of the v12 build capabilities (as described by the migration docs as of #220) so that it doesn't do a "dev-publish" for forked-PRs (as they won't have access to the context this needs) and it only "pack"s if tests worked (no point packing if the build has failed).

i.e. This makes the example consistent with the build process enabled/described/used by this orb.
