### PR TITLE
Improve migration docs - build code

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,25 +11,29 @@ workflows:
     jobs:
       - orb-tools-alpha/lint:
           filters: *filters
-      - orb-tools-alpha/pack:
-          filters: *filters
       - orb-tools-alpha/review:
           filters: *filters
+      - orb-tools-alpha/pack:
+          filters: *filters
+          requires:
+            - orb-tools-alpha/lint
+            - orb-tools-alpha/review
       - orb-tools-alpha/publish:
           name: publish_dev_test
           orb_name: circleci/orb-tools
           vcs_type: <<pipeline.project.type>>
           pub_type: dev
           github_token: GHI_TOKEN
-          requires:
-            [orb-tools-alpha/lint, orb-tools-alpha/review, orb-tools-alpha/pack]
+          requires: [orb-tools-alpha/pack]
           context: orb-publisher
+          filters:
+            branches:
+              ignore: /pull/[0-9]+/
       - orb-tools-alpha/publish:
           orb_name: circleci/orb-tools
           vcs_type: <<pipeline.project.type>>
           pub_type: production
-          requires:
-            [orb-tools-alpha/lint, orb-tools-alpha/review, orb-tools-alpha/pack, publish_dev_test]
+          requires: [orb-tools-alpha/pack]
           context: orb-publisher
           github_token: GHI_TOKEN
           filters:


### PR DESCRIPTION
Split from #220 as CCI can't accept PRs that update the docs, examples and build code all in the same PR.

This PR updates the build code _used for this orb_ to best take advantage of the v12 build capabilities (as described by the migration docs as of #220) so that it doesn't do a "dev-publish" for forked-PRs (as they won't have access to the context this needs) and it only "pack"s if tests worked (no point packing if the build has failed).

This makes the build of this orb consistent with the build process that its documentation recommends.