### PR TITLE
Add pack job to test-deploy example

### DIFF
--- a/src/examples/step2_test-deploy.yml
+++ b/src/examples/step2_test-deploy.yml
@@ -33,12 +33,17 @@ usage:
             filters:
               tags:
                 only: /.*/
+        - orb-tools/pack:
+            filters:
+              tags:
+                only: /.*/
         # Because our publishing job has a tag filter, we must also apply a filter to each job it depends on.
         - orb-tools/publish:
             orb_name: <namespace>/<my-orb>
             pub_type: production
             vcs_type: <<pipeline.project.type>>
             requires:
+              - orb-tools/pack
               - command-tests
               - <my-orb>/my_job
             context: [orb-publishing-context]


### PR DESCRIPTION
To publish the Orb on a tag, `orb-tools/pack` job is required and is inside of our Orb template: 
* https://github.com/CircleCI-Public/Orb-Template/blob/main/.circleci/test-deploy.yml#L40-L41

If a user does not use the template and follows the example on the Orb page, they will run into an issue where the `orb-tools/publish` job cannot attach a workspace from the `orb-tools/pack` job since it is not run.