### PR TITLE
Update default.yml

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   tag:
     type: string
-    default: "0.1.26646"
+    default: "latest"
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags


### PR DESCRIPTION
This PR updates the image tag for the default executor to "latest". The currently pinned version does not work with checkouts for GitHub App projects.