### PR TITLE
feat: Support CircleCI IP Ranges

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -13,6 +13,10 @@ parameters:
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 resource_class: << parameters.resource_class >>
 docker:

--- a/src/executors/python.yml
+++ b/src/executors/python.yml
@@ -13,6 +13,10 @@ parameters:
     type: enum
     enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
     default: "medium"
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 resource_class: << parameters.resource_class >>
 docker:

--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -55,6 +55,10 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 executor: << parameters.executor >>
 

--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -15,6 +15,10 @@ parameters:
     description: The executor to use for this job. By default, this will use the "python" executor provided by this orb.
     type: executor
     default: python
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 executor: << parameters.executor >>
 

--- a/src/jobs/pack.yml
+++ b/src/jobs/pack.yml
@@ -45,6 +45,10 @@ parameters:
       You can use "org_id" instead if you prefer.
     type: string
     default: ""
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 executor: << parameters.executor >>
 

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -84,6 +84,10 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
   attach_workspace:
     type: boolean
     default: true

--- a/src/jobs/review.yml
+++ b/src/jobs/review.yml
@@ -36,6 +36,10 @@ parameters:
     description: The executor to use for this job. By default, this will use the "python" executor provided by this orb.
     type: executor
     default: python
+  circleci_ip_ranges:
+    description: Enables jobs to go through a set of well-defined IP address ranges.
+    type: boolean
+    default: false
 
 executor: << parameters.executor >>
 

--- a/src/scripts/review.bats
+++ b/src/scripts/review.bats
@@ -44,7 +44,7 @@ setup() {
 	fi
 }
 
-@test "RC004: Usage example names shoud be descriptive." {
+@test "RC004: Usage example names should be descriptive." {
 	if [[ "${SKIPPED_REVIEW_CHECKS[*]}" =~ "RC004" ]]; then
 		skip
 	fi


### PR DESCRIPTION
This PR is intended to add support for the CircleCI IP Ranges feature to the Orb Tools Orb.

https://circleci.com/docs/ip-ranges/

By supporting this flag, it means organizations which limit the source IPs accessing their source code can still utilize this orb and it's need to checkout code, without the orb needing to be duplicated or hacked apart to support this in any way.

I also snuck in a minor typo fix in one of the tests.
