### PR TITLE
Enables Support for tracking Orb Releaes in CircleCI Releases

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -96,6 +96,10 @@ parameters:
       This will attempt to attach the workspace at the path specified by the "orb_dir" parameter.
       It is expected that the workspace will contain 'orb_source.tar.gz' which should contain one or more orb source files.
       The tar file will be extracted to the "orb_dir" path.
+  release_environment:
+    description: Enables tracking of the orb release in a defined CircleCI Release's environment. Passing in no environment name will disable tracking.
+    type: string
+    default: ""
 
 executor: << parameters.executor >>
 
@@ -125,6 +129,7 @@ steps:
         ORB_VAL_TAG_PATTERN: <<parameters.tag_pattern>>
         ORB_VAL_DEV_TAGS: <<parameters.dev_tags>>
         ORB_VAL_CIRCLECI_API_HOST: <<parameters.circleci_api_host>>
+        ORB_VAL_RELEASE_ENVIRONMENT: <<parameters.release_environment>>
       command: <<include(scripts/publish.sh)>>
   - when:
       condition: <<parameters.enable_pr_comment>>

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -27,6 +27,12 @@ function publishOrb() {
   #$1 = full tag
 
   circleci orb publish --host "${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" --skip-update-check "${ORB_DIR}/${ORB_FILE}" "${ORB_VAL_ORB_NAME}@${1}" --token "$ORB_VAL_ORB_PUB_TOKEN"
+
+  # Track release if ORB_VAL_RELEASE_ENVIRONMENT is set
+  if [[ -n "${ORB_VAL_RELEASE_ENVIRONMENT}" ]]; then
+    circleci run release log --environment-name="${ORB_VAL_RELEASE_ENVIRONMENT}" --component-name="${ORB_VAL_ORB_NAME}" --target-version="${1}"
+  fi
+  
   printf "\n"
   {
     printf "Your orb has been published to the CircleCI Orb Registry.\n"

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -30,7 +30,7 @@ function publishOrb() {
 
   # Track release if ORB_VAL_RELEASE_ENVIRONMENT is set
   if [[ -n "${ORB_VAL_RELEASE_ENVIRONMENT}" ]]; then
-    circleci run release log --environment-name="${ORB_VAL_RELEASE_ENVIRONMENT}" --component-name="${ORB_VAL_ORB_NAME}" --target-version="${1}"
+    circleci-agent run release log --environment-name="${ORB_VAL_RELEASE_ENVIRONMENT}" --component-name="${ORB_VAL_ORB_NAME}" --target-version="${1}"
   fi
   
   printf "\n"


### PR DESCRIPTION
The changes below add support for CircleCI's Releases. This addition adds an optional parameter to the publish job called `release_environment`. If `release_environment` is set, upon releasing a new version of the orb the release itself will be tracked in the supplied environment. 

Note users will need to make a custom environment type in CircleCI Releases and then pass that environment name as the parameter. 

By default `release_environment` is set to an empty string, which will skip over the release tracking. This should not break any usage of the existing orb tools. 