### PR TITLE
feat: conditional steps are now reviewed by RC008, RC009

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ orbs:
   # For the orb-tools-orb it must call itself within the first workflow,
   #   meaning this dev version will need to be published every 90 days.
   # No other orbs will need to import themselves here.
-  orb-tools-alpha: circleci/orb-tools@12.1.0
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools-alpha: circleci/orb-tools@12.2.0
+  shellcheck: circleci/shellcheck@3.2.0
 
 filters: &filters
   tags:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -11,4 +11,4 @@ display:
 
 orbs:
   cli: circleci/circleci-cli@0.1.9
-  bats: circleci/bats@1.0.0
+  bats: circleci/bats@1.1.0

--- a/src/scripts/review.sh
+++ b/src/scripts/review.sh
@@ -7,14 +7,14 @@ fi
 if ! command -v yq >/dev/null; then
 	echo 'The "yq" package must be installed to execute review testing.'
 	echo 'Installing "yq" automatically...'
-	YQ_VERSION=v4.20.1
+	YQ_VERSION=v4.44.6
 	YQ_BIN=yq_linux_amd64
 	wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BIN}.tar.gz -O - |
 		tar xz && mv ${YQ_BIN} /usr/bin/yq
 fi
 
 mkdir -p /tmp/orb_dev_kit/review/
-echo "$ORB_VAL_REVIEW_BATS_FILE" >review.bats
+echo "$ORB_VAL_REVIEW_BATS_FILE" > review.bats
 echo "Reviewing orb best practices"
 echo "If required, tests can be skipped via their \"RCXXX\" code with the \"exclude\" parameter."
 bats -T --pretty --report-formatter junit --output /tmp/orb_dev_kit/review ./review.bats


### PR DESCRIPTION
## Orb version:

v11.1.0 + including v12

## What happened:

First described in #128 by @wyardley, run-steps within conditional steps are not checked by RC008 and RC009

## Expected behavior:

This is expected to fail RC008 and RC009

```yaml
steps:
  - checkout
  - restore-deps
  - run: npm run thing1
  - when:
      condition: << parameters.run-thing2 >>
      steps:
        run: npm run thing2
```

## Additional Information:

This PR fixes issue #132 
