### PR TITLE
feat(jobs): support `circleci` VCS type

### DIFF
--- a/src/jobs/continue.yml
+++ b/src/jobs/continue.yml
@@ -13,6 +13,7 @@ parameters:
       - github
       - bb
       - bitbucket
+      - circleci
   config_path:
     description: Path to the next config file to execute. By default, this will execute the "test_deploy" workflow.
     type: string

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -44,6 +44,7 @@ parameters:
       - github
       - bb
       - bitbucket
+      - circleci
   github_token:
     description: |
       For GitHub users with "enable_pr_comment" enabled, the GitHub API token must be set.


### PR DESCRIPTION
I couldn't find docs easily at https://circleci.com/docs/api/v2/index.html, though what I could find (e.g., https://circleci.com/docs/api/v2/index.html#tag/Project/operation/getProjectSettings) seems to confirm that a) circleci is a valid vcs type and b) that it's also the type that should be used for GitLab.

Let me know if this is the wrong fix, and also if there are any additional values that should be added, or if there should be a note about GitLab users in the description / docs.

https://discuss.circleci.com/t/type-error-for-argument-vcs-type/51465/4