### PR TITLE
update the default to use latest circlecicli image

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ description: >
 parameters:
   tag:
     type: string
-    default: "0.1.26646"
+    default: "latest"
     description: >
       What version of the CircleCI CLI Docker image? For full list, see
       https://hub.docker.com/r/circleci/circleci-cli/tags


### PR DESCRIPTION
there's a breaking change with old versions of the CircleCI CLI, it's probably best to just keep this on the latest image?

https://discuss.circleci.com/t/upcoming-breaking-change-to-circleci-local-cli-may-31-2025/52576