### PR TITLE
feat: add the possibility to pack private orbs by checking a CIRCLE_TOKEN env var

### DIFF
--- a/src/scripts/pack.sh
+++ b/src/scripts/pack.sh
@@ -2,5 +2,10 @@
 ORB_DIR=${ORB_VAL_ORB_DIR%/}
 ORB_FILE=${ORB_VAL_ORB_FILE_NAME#/}
 
-mkdir -p "$ORB_VAL_ORB_DIR" &&
-  circleci orb pack --skip-update-check "$ORB_VAL_SOURCE_DIR" >"${ORB_DIR}/${ORB_FILE}"
+if [ -n "${CIRCLE_TOKEN}" ]; then
+    mkdir -p "$ORB_VAL_ORB_DIR" &&
+      circleci orb pack --token "${CIRCLE_TOKEN}" --skip-update-check "$ORB_VAL_SOURCE_DIR" >"${ORB_DIR}/${ORB_FILE}"
+else
+  mkdir -p "$ORB_VAL_ORB_DIR" &&
+    circleci orb pack --skip-update-check "$ORB_VAL_SOURCE_DIR" >"${ORB_DIR}/${ORB_FILE}"
+fi


### PR DESCRIPTION
# Issue
orb-tools has an issue where if attempting to pack an orb that depends on a private orb, the job fails. 

# Solution
We are adding a validation that checks if the environment variable CIRCLE_TOKEN is available to use it during the `circleci orb pack` step.