### PR TITLE
docs: Fix orb_name reference to actually be injectable

### DIFF
--- a/src/examples/step1_lint-pack.yml
+++ b/src/examples/step1_lint-pack.yml
@@ -9,8 +9,8 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    orb-tools: circleci/orb-tools@12.0
-    shellcheck: circleci/shellcheck@3.1
+    orb-tools: circleci/orb-tools@<version>
+    shellcheck: circleci/shellcheck@3.4.0
 
   workflows:
     lint-pack:
@@ -37,7 +37,8 @@ usage:
         - orb-tools/continue:
             pipeline_number: << pipeline.number >>
             vcs_type: << pipeline.project.type >>
-            orb_name: <orb name>
+            orb_name: <my-orb>
+            # config_path: .circleci/test_deploy.yml
             requires:
               - orb-tools/lint
               - orb-tools/review

--- a/src/examples/step2_test-deploy.yml
+++ b/src/examples/step2_test-deploy.yml
@@ -7,7 +7,8 @@ description: |
 usage:
   version: 2.1
   orbs:
-    orb-tools: circleci/orb-tools@12.0
+    orb-tools: circleci/orb-tools@<version>
+    <my-orb>: {}
     # The orb will be injected here by the "continue" job.
   jobs:
     # Create a job to test the commands of your orbs.


### PR DESCRIPTION
Hi there,
while working with https://github.com/CircleCI-Public/Orb-Template/tree/main i figured out that the example for the orb name injection was wrong and not working. You can read about the details in the docs but a good example comes with batteries included.

I also added a hint why the test_deploy.yml file is loaded and updated the orb versions. The orb-tools version should now come from a variable.