### PR TITLE
Use real orb version in examples

### DIFF
--- a/src/examples/step1_lint-pack.yml
+++ b/src/examples/step1_lint-pack.yml
@@ -9,7 +9,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    orb-tools: circleci/orb-tools@<version>
+    orb-tools: circleci/orb-tools@12.3
     shellcheck: circleci/shellcheck@3.4.0
 
   workflows:

--- a/src/examples/step2_test-deploy.yml
+++ b/src/examples/step2_test-deploy.yml
@@ -7,7 +7,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    orb-tools: circleci/orb-tools@<version>
+    orb-tools: circleci/orb-tools@12.3
     <my-orb>: {}
     # The orb will be injected here by the "continue" job.
   jobs:


### PR DESCRIPTION
This should resolve an error we're seeing when trying to publish a new version: https://app.circleci.com/pipelines/github/CircleCI-Public/orb-tools-orb/1243/workflows/c692f6d9-b6d4-4823-8d01-0777c1d8680b/jobs/7977