### PR TITLE
Add pip_break parameter to lint job for system package installation

### DIFF
--- a/src/jobs/lint.yml
+++ b/src/jobs/lint.yml
@@ -19,6 +19,10 @@ parameters:
     description: Enables jobs to go through a set of well-defined IP address ranges.
     type: boolean
     default: false
+  pip_break:
+    description: Put --break-system-packages flag on pip install
+    type: boolean
+    default: false
 
 executor: << parameters.executor >>
 
@@ -34,3 +38,4 @@ steps:
       command: <<include(scripts/lint.sh)>>
       environment:
         ORB_VAL_SOURCE_DIR: << parameters.source_dir >>
+        PIP_BREAK: << parameters.pip_break >>

--- a/src/scripts/lint.sh
+++ b/src/scripts/lint.sh
@@ -5,5 +5,9 @@ if [ ! -d "$ORB_VAL_SOURCE_DIR" ]; then
     printf "https://circleci.com/docs/orbs/author/orb-development-kit/\n"
     exit 1
 fi
-pip install --user yamllint
+if [ "$PIP_BREAK" = true ]; then
+    pip install --user --break-system-packages yamllint
+else
+    pip install --user yamllint
+fi
 yamllint "$ORB_VAL_SOURCE_DIR"


### PR DESCRIPTION
Adds a new `pip_break` boolean parameter to the lint job that allows users to pass the `--break-system-packages` flag to pip install when needed. The parameter defaults to false to maintain backward compatibility.

Ran into this issue recently while executing my pipeline.