### PR TITLE
Adapt to CLI major version and use native commands for V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ Follow the [migration guide](./MIGRATION.md).
 
 A subset of the orb-tools orb jobs and scripts can be ran locally. It is useful to be able to lint, shellcheck, and review your orbs locally, before committing. With this setup, it is possible to test your _code_ locally, but integration tests of the built orb will be ran on CircleCI.
 
+**Note:** The `circleci local execute` command used below is only available in the `0.1.x` CircleCI CLI. Version 1 of the CLI does not run jobs locally, so on v1 use the direct tool invocations (`yamllint`, `shellcheck`, `bats`) documented alongside each job. Check which version you have with `circleci version`.
+
 ### Local Linting
 
 The orb-tools orb's `orb-tools/lint` job uses a utility [yamllint](https://yamllint.readthedocs.io/en/stable/), which can be downloaded an ran locally, or you can invoke the job locally with the CircleCI CLI.
 
 Assuming you `./circleci/config.yml` file appears similar to the one in this repository, you will have imported the orb-tools orb and defined the `orb-tools/lint` job in a workflow. Using the CLI from this directory, use the following command to locally lint your orb:
 
-#### CircleCI Local Linting
+#### CircleCI Local Linting (CLI `0.1.x` only)
 
 ```shell
 $ circleci local execute --job orb-tools/lint
@@ -50,7 +52,7 @@ Note: you will need a `.yamllint` file in the current directory to run the yamll
 
 [Shellcheck](https://github.com/koalaman/shellcheck) is a static analysis tool for shell scripts, and behaves like a linter for our shell scripts. Which of course can also be ran locally, or if defined within your configuration file, you can invoke the job locally with the CircleCI CLI.
 
-#### CircleCI Local Shellcheck
+#### CircleCI Local Shellcheck (CLI `0.1.x` only)
 
 ```shell
 $ circleci local execute --job shellcheck/check
@@ -68,7 +70,7 @@ $ shellcheck ./src/scripts/*.sh --exclude SC2148,SC2038,SC2086,SC2002,SC2016
 
 The `review` job is a suite of Bash unit tests written using [bats-core](https://github.com/bats-core/bats-core), a test automation framework for Bash. Each test focuses on checking for a best practice in the orb. The tests can be executed directly with the `bats` CLI, or you can invoke the job locally with the CircleCI CLI.
 
-#### CircleCI Local Review
+#### CircleCI Local Review (CLI `0.1.x` only)
 
 ```shell
 $ circleci local execute --job orb-tools/review

--- a/src/scripts/publish.sh
+++ b/src/scripts/publish.sh
@@ -26,7 +26,14 @@ function validateOrbPubToken() {
 function publishOrb() {
   #$1 = full tag
 
-  circleci orb publish --host "${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" --skip-update-check "${ORB_DIR}/${ORB_FILE}" "${ORB_VAL_ORB_NAME}@${1}" --token "$ORB_VAL_ORB_PUB_TOKEN"
+  if [ "${CLI_MAJOR_VERSION:-1}" -ge 1 ]; then
+    # The v1 CLI reads the host and token from CIRCLE_HOST/CIRCLE_TOKEN instead of --host/--token.
+    CIRCLE_HOST="${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" \
+      CIRCLE_TOKEN="$ORB_VAL_ORB_PUB_TOKEN" \
+      circleci orb publish "${ORB_DIR}/${ORB_FILE}" "${ORB_VAL_ORB_NAME}@${1}"
+  else
+    circleci orb publish --host "${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" --skip-update-check "${ORB_DIR}/${ORB_FILE}" "${ORB_VAL_ORB_NAME}@${1}" --token "$ORB_VAL_ORB_PUB_TOKEN"
+  fi
 
   # Track release if ORB_VAL_RELEASE_ENVIRONMENT is set
   if [[ -n "${ORB_VAL_RELEASE_ENVIRONMENT}" ]]; then
@@ -92,5 +99,6 @@ function orbPublish() {
 
 ORB_RELEASE_VERSION=""
 ORB_VAL_ORB_PUB_TOKEN=${!ORB_VAL_ORB_PUB_TOKEN}
+CLI_MAJOR_VERSION=$(circleci version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -n1 | cut -d. -f1)
 mkdir -p /tmp/orb_dev_kit/
 orbPublish

--- a/src/scripts/validate.sh
+++ b/src/scripts/validate.sh
@@ -11,4 +11,15 @@ if [ "https://circleci.com" != "${ORB_VAL_CIRCLECI_API_HOST}" ] && [ -z "${CIRCL
     exit 1
 fi
 
-circleci orb validate --host "${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" --token "${CIRCLE_TOKEN:-dummy}" ${ORB_VAL_ORG_ID:+--org-id "$ORB_VAL_ORG_ID"} ${ORB_VAL_ORG_SLUG:+--org-slug "$ORB_VAL_ORG_SLUG"} --skip-update-check "${ORB_DIR}/${ORB_FILE}"
+# The v1 CircleCI CLI reads the host and token from CIRCLE_HOST/CIRCLE_TOKEN instead of
+# --host/--token, and replaced --org-id/--org-slug with a single --org taking either form.
+CLI_MAJOR_VERSION=$(circleci version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -n1 | cut -d. -f1)
+
+if [ "${CLI_MAJOR_VERSION:-1}" -ge 1 ]; then
+  ORB_VAL_ORG=${ORB_VAL_ORG_ID:-$ORB_VAL_ORG_SLUG}
+  CIRCLE_HOST="${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" \
+    CIRCLE_TOKEN="${CIRCLE_TOKEN:-dummy}" \
+    circleci orb validate ${ORB_VAL_ORG:+--org "$ORB_VAL_ORG"} "${ORB_DIR}/${ORB_FILE}"
+else
+  circleci orb validate --host "${ORB_VAL_CIRCLECI_API_HOST:-https://circleci.com}" --token "${CIRCLE_TOKEN:-dummy}" ${ORB_VAL_ORG_ID:+--org-id "$ORB_VAL_ORG_ID"} ${ORB_VAL_ORG_SLUG:+--org-slug "$ORB_VAL_ORG_SLUG"} --skip-update-check "${ORB_DIR}/${ORB_FILE}"
+fi


### PR DESCRIPTION
- V1 has a V0 backwards compatibility layer, but we don't want to use it forever.